### PR TITLE
Fix `log_request_body` failing on Django 1.10

### DIFF
--- a/binder/router.py
+++ b/binder/router.py
@@ -1,4 +1,5 @@
 import django
+from django.urls import reverse
 
 from .exceptions import BinderRequestError, BinderCSRFFailure, BinderMethodNotAllowed
 
@@ -99,7 +100,7 @@ class Router(object):
 
 	def model_route(self, model, pk=None, field=None):
 		if not model in self.model_routes:
-			self.model_routes[model] = django.core.urlresolvers.reverse(model.__name__)
+			self.model_routes[model] = reverse(model.__name__)
 		route = self.model_routes[model]
 
 		if pk and field:

--- a/binder/views.py
+++ b/binder/views.py
@@ -156,7 +156,7 @@ class ModelView(View):
 		# So we're good for most requests. For file uploads, we proceed without body logging.
 		if not self.log_request_body:
 			body = ' censored.'
-		elif not hasattr(request, '_post'):
+		elif request.method in ('HEAD', 'GET'):
 			body = ' unavailable.'
 		else:
 			if request.META.get('CONTENT_TYPE', '').lower() == 'application/json':

--- a/binder/views.py
+++ b/binder/views.py
@@ -170,7 +170,7 @@ class ModelView(View):
 		try:
 			#### START TRANSACTION
 			with transaction.atomic():
-				if not kwargs.pop('unauthenticated', False) and not request.user.is_authenticated():
+				if not kwargs.pop('unauthenticated', False) and not request.user.is_authenticated:
 					raise BinderNotAuthenticated()
 
 				if 'method' in kwargs:
@@ -1174,7 +1174,7 @@ def debug_changesets_24h(request):
 	if request.method != 'GET':
 		raise BinderMethodNotAllowed()
 
-	if not request.user.is_authenticated():
+	if not request.user.is_authenticated:
 		logger.warning('Not authenticated.')
 		return HttpResponseForbidden('Not authenticated.')
 

--- a/binder/views.py
+++ b/binder/views.py
@@ -156,7 +156,7 @@ class ModelView(View):
 		# So we're good for most requests. For file uploads, we proceed without body logging.
 		if not self.log_request_body:
 			body = ' censored.'
-		elif not hasattr(request, '_body') and request._read_started:
+		elif not hasattr(request, '_post'):
 			body = ' unavailable.'
 		else:
 			if request.META.get('CONTENT_TYPE', '').lower() == 'application/json':


### PR DESCRIPTION
In Django 1.10, doing a GET on a route results in: `ValueError: invalid literal for int() with base 10: ''`. Following the stacktrace, this is because of something Django does in `request.body`.

So apparently, using `request.body` on a GET request will now result in this error.

According to the tests I did, `request._post` is always available when `request.body` is accessible without an error.

Maybe it's cleaner to only log `request.body` when the method is not `HEAD` or `GET`? Didn't yet test if that would work though.

This is not yet tested on Django 1.9.