### PR TITLE
Remove singleton pattern from Router class (#28).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 ### Views
 
 - Multiput now supports softdeleting related models. (#24)
+
+### Router
+
+- Router is no longer a singleton (#28; **backwards incompatible**)

--- a/docs/install.md
+++ b/docs/install.md
@@ -30,10 +30,10 @@ import binder.router
 import binder.views
 import binder.models
 
-binder.router.Router().register(binder.views.ModelView)
+router = binder.router.Router().register(binder.views.ModelView)
 
 urlpatterns = [
-	url(r'^', include(binder.router.Router().urls)),
+	url(r'^', include(router.urls)),
 	url(r'^', binder.views.api_catchall, name='catchall'),
 ]
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -18,14 +18,7 @@ class BarModel(BinderModel):
 
 
 class RouterTest(TestCase):
-	def setUp(self):
-		# Defeat singleton hackery for now, until #28 is resolved.
-		Router.model_views = {}
-		Router.route_views = {}
-		Router.model_routes = {}
-		Router.name_models = {}
-		# Ugh, more hackery
-		urls_module.urlpatterns = []
+	def tearDown(self):
 		# Without this, tests can influence one another!
 		clear_url_caches()
 

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -7,11 +7,11 @@ import binder.models
 
 from .views import animal, caretaker, costume, custom, zoo
 
-binder.router.Router().register(binder.views.ModelView)
+router = binder.router.Router().register(binder.views.ModelView)
 
 urlpatterns = [
 	url(r'^custom/route', custom.custom, name='custom'),
-	url(r'^', include(binder.router.Router().urls)),
+	url(r'^', include(router.urls)),
 	url(r'^', binder.views.api_catchall, name='catchall'),
 ]
 


### PR DESCRIPTION
Instead, we pass the router to the view class in kwargs, which it then
saves as a property on itself.

This allows us to instantiate multiple routers, for example in the
tests, but it also makes it easier to combine multiple apps which all
rely on Binder.

This is a backwards incompatible change!

Fixes #28
