### PR TITLE
add ?with=related_model to POST/PUT requests

### DIFF
--- a/binder/views.py
+++ b/binder/views.py
@@ -960,9 +960,8 @@ class ModelView(View):
 		new = dict(data)
 		new.pop('_meta', None)
 
-		extras, extras_mapping = self._get_withs([new['id']], request=request)
-		data['_meta']['with'] = extras
-		data['_meta']['with_mapping'] = extras_mapping
+		meta = data['_meta']
+		meta['with'], meta['with_mapping'] = self._get_withs([new['id']], request=request)
 
 		logger.info('PUT updated {} #{}'.format(self._model_name(), pk))
 		for c in self._obj_diff(old, new, '{}[{}]'.format(self._model_name(), pk)):
@@ -990,9 +989,8 @@ class ModelView(View):
 		new = dict(data)
 		new.pop('_meta', None)
 
-		extras, extras_mapping = self._get_withs([new['id']], request=request)
-		data['_meta']['with'] = extras
-		data['_meta']['with_mapping'] = extras_mapping
+		meta = data['_meta']
+		meta['with'], meta['with_mapping'] = self._get_withs([new['id']], request=request)
 
 		logger.info('POST created {} #{}'.format(self._model_name(), data['id']))
 		for c in self._obj_diff({}, new, '{}[{}]'.format(self._model_name(), data['id'])):

--- a/binder/views.py
+++ b/binder/views.py
@@ -278,7 +278,6 @@ class ModelView(View):
 		ids = list(ids)
 
 		# Make sure to include A if A.B is specified.
-		# TODO: include A if A.B.C is specified
 		for w in withs:
 			if '.' in w:
 				withs.append('.'.join(w.split('.')[:-1]))

--- a/tests/test_model_view_basics.py
+++ b/tests/test_model_view_basics.py
@@ -412,3 +412,33 @@ class ModelViewBasicsTest(TestCase):
 		artis = Zoo.objects.get(id=returned_data.get('id'))
 		self.assertEqual('Artis', artis.name)
 		self.assertSetEqual(set([scooby.id, scrappy.id]), set([a.id for a in artis.animals.all()]))
+
+
+	def test_post_put_respect_with_clause(self):
+		emmen = Zoo(name='Wildlands Adventure Zoo Emmen')
+		emmen.full_clean()
+		emmen.save()
+
+		model_data = {
+			'name': 'Scooby Doo',
+			'zoo': emmen.pk,
+		}
+		response = self.client.post(
+			'/animal/?with=zoo',
+			data=json.dumps(model_data),
+			content_type='application/json'
+		)
+
+		self.assertEqual(response.status_code, 200)
+		result = jsonloads(response.content)
+		self.assertEqual(1, len(result['_meta']['with']['zoo']))
+
+		response = self.client.put(
+			'/animal/{}/?with=zoo'.format(result['id']),
+			data=json.dumps(model_data),
+			content_type='application/json'
+		)
+
+		self.assertEqual(response.status_code, 200)
+		result = jsonloads(response.content)
+		self.assertEqual(1, len(result['_meta']['with']['zoo']))


### PR DESCRIPTION
When creating a model, it's nice to be able to get all the related values so it's possible to build a complete view of the model with an extra fetch.

So, this PR adds complete support for `withs` for `PUT` and `POST` requests.

EDIT: Travis failure is unrelated and is fixed by https://github.com/CodeYellowBV/django-binder/pull/35