### PR TITLE
Abstract model views

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -255,6 +255,29 @@ accept the following keyword options:
 - `extra_route`: An optional string suffix to append to the route. You can use named capturing groups here, just like in `urls.py`.
 
 
+## Abstract views
+Sometimes you need to define some logic in the API in more than one model view. Of course copy pasting is bad. Therefore the best solution 
+is to extend the model view. Since the router automatically adds all views, you need to define the view abstract. This can be done in a similar
+manner as Django allows models to be abstract.
+
+```python
+# This view does not get added to the router
+class AbstractView(ModelView):
+	class Meta:
+		abstract=True
+		
+	# Put your custom logic here
+
+# This class uses the custom logic from the abstract view
+# Also it is added to the router
+class ConcreteView(AbstractView):
+	model = ConcreteModel
+
+```
+
+
+
+
 TODO:
 
 - how to add custom saving logic

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,10 @@
+# Testing
+
+## Build the app
+The first step is to run the app
+```python3 setup.py install```
+
+## Running unittest
+After building unittests can be run by the following command:
+```python3 setup.py test```
+This will download and install all dependencies, and then run the.

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -118,3 +118,43 @@ class RouterTest(TestCase):
 
 		self.assertTrue(is_valid_path('/bar/', urls_module))
 		self.assertFalse(is_valid_path('/bar/1/', urls_module))
+
+	def test_non_abstract_view_needs_model(self):
+		class ParentView(ModelView):
+			pass
+		class ChildView(ParentView):
+			'''
+			Child view is not abstaract. Router will raise an error that no model is defined
+			'''
+			pass
+		r = Router()
+		with self.assertRaises(AttributeError):
+			r.register(ParentView)
+
+	def test_abstract_views_not_registered(self):
+		class ParentView(ModelView):
+			pass
+		class ChildView(ParentView):
+			class Meta:
+				abstract=True
+		r = Router()
+
+		# This
+		r.register(ParentView)
+		self.assertEqual(0, len(r.model_views))
+
+	def test_subviews_of_abstract_views_registered(self):
+		class ParentView(ModelView):
+			pass
+
+		class ChildView(ParentView):
+			class Meta:
+				abstract = True
+
+		class FooView(ChildView):
+			model=FooModel
+
+		r = Router()
+		r.register(ParentView)
+		urls_module.urlpatterns = [url(r'^', include(r.urls))]
+		self.assertTrue(is_valid_path('/foo_model/', urls_module))


### PR DESCRIPTION
This patch allows the user to define extensions of a model view by defining a model view abstract

In the current implementation this is not possible, because the router registers the model view automatically. Since the model view is not associated to a view, this triggers an error. 