### PR TITLE
Add support for JSON serializing `decimal.Decimal`

### DIFF
--- a/binder/json.py
+++ b/binder/json.py
@@ -25,14 +25,12 @@ class BinderJSONEncoder(json.JSONEncoder):
 			return obj.strftime("%Y-%m-%dT%H:%M:%S.%f") + tz
 		elif isinstance(obj, datetime.date):
 			return obj.isoformat()
-		elif isinstance(obj, UUID):
+		elif isinstance(obj, (UUID, Decimal)):
 			return str(obj)  # Standard string notation
 		elif isinstance(obj, set):
 			return list(obj)
 		elif isinstance(obj, relativedelta):
 			return format_relativedelta(obj)
-		elif isinstance(obj, Decimal):
-			return float(obj)
 		return json.JSONEncoder.default(self, obj)
 
 

--- a/binder/json.py
+++ b/binder/json.py
@@ -1,6 +1,7 @@
 import json
 import datetime
 from uuid import UUID
+from decimal import Decimal
 
 from django.http import HttpResponse
 
@@ -30,6 +31,8 @@ class BinderJSONEncoder(json.JSONEncoder):
 			return list(obj)
 		elif isinstance(obj, relativedelta):
 			return format_relativedelta(obj)
+		elif isinstance(obj, Decimal):
+			return float(obj)
 		return json.JSONEncoder.default(self, obj)
 
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -2,6 +2,7 @@ import json as python_core_json
 
 from datetime import datetime, date
 from uuid import UUID
+from decimal import Decimal
 from django.test import TestCase
 
 import binder.json as binder_json
@@ -53,3 +54,7 @@ class JsonTest(TestCase):
 	def test_uuids_dump_correctly(self):
 		u = UUID('{12345678-1234-5678-1234-567812345678}')
 		self.assertEqual('["12345678-1234-5678-1234-567812345678"]', binder_json.jsondumps([u]))
+
+	def test_decimals_dump_correctly(self):
+		u = Decimal('1.1')
+		self.assertEqual('[1.1]', binder_json.jsondumps([u]))

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -57,4 +57,4 @@ class JsonTest(TestCase):
 
 	def test_decimals_dump_correctly(self):
 		u = Decimal('1.1')
-		self.assertEqual('[1.1]', binder_json.jsondumps([u]))
+		self.assertEqual('["1.1"]', binder_json.jsondumps([u]))


### PR DESCRIPTION
In Django you can use a Decimal field in a model, but when you do that it gives a 500 error because it can't serialize a Decimal field to JSON. This fixes that.