### PR TITLE
Use pk for relation filtering

### DIFF
--- a/binder/views.py
+++ b/binder/views.py
@@ -364,19 +364,7 @@ class ModelView(View):
 
 		next = self._follow_related(head)[0].model
 
-		# In most binder apps we use the Profile model which doesn't have an id,
-		# but it references the User model.
-		#
-		# This code normally checks for the foreign key to the related model on this model.
-		# This fails as a User doesn't have a profile_id.
-		# Instead, a profile has no own foreign key, and uses its user_id as fk.
-		#
-		# If the related model has no `id` as pk, and it uses the foreign key to this model as private key:
-		# use the ids of this model as pks
-		if next._meta.pk.name != 'id' and next._meta.pk.related_model == self.model:
-			pks = list(self.model.objects.filter(pk__in=pks).values_list('id', flat=True))
-		else:
-			pks = list(self.model.objects.filter(pk__in=pks).values_list(head + '__id', flat=True))
+		pks = list(self.model.objects.filter(pk__in=pks).values_list(head + '__pk', flat=True))
 		view_class = self.router.model_view(next)
 
 		if not tail:

--- a/tests/testapp/models/__init__.py
+++ b/tests/testapp/models/__init__.py
@@ -3,4 +3,5 @@ from .animal import Animal
 from .caretaker import Caretaker
 from .contact_person import ContactPerson
 from .costume import Costume
+from .gate import Gate
 from .zoo import Zoo

--- a/tests/testapp/models/gate.py
+++ b/tests/testapp/models/gate.py
@@ -1,0 +1,14 @@
+from django.db import models
+
+import binder.models
+from binder.models import BinderModel
+
+class Gate(BinderModel):
+	class Meta:
+		ordering = ['zoo_id']
+
+	zoo=models.OneToOneField('Zoo', on_delete=models.CASCADE, primary_key=True, related_name='gate')
+	keeper=models.ForeignKey('Caretaker', on_delete=models.CASCADE, related_name='gate', blank=True, null=True)
+
+	def __str__(self):
+		return 'gate %d: of %s)' % (self.pk or 0, self.zoo)

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -4,8 +4,7 @@ import binder.router
 import binder.views
 import binder.history
 import binder.models
-
-from .views import animal, caretaker, costume, custom, zoo, contact_person
+from .views import animal, caretaker, costume, custom, zoo, contact_person, gate
 
 router = binder.router.Router().register(binder.views.ModelView)
 

--- a/tests/testapp/views/__init__.py
+++ b/tests/testapp/views/__init__.py
@@ -3,4 +3,5 @@ from .animal import AnimalView
 from .caretaker import CaretakerView
 from .contact_person import ContactPersonView
 from .costume import CostumeView
+from .gate import GateView
 from .zoo import ZooView

--- a/tests/testapp/views/gate.py
+++ b/tests/testapp/views/gate.py
@@ -1,0 +1,6 @@
+from binder.views import ModelView
+
+from ..models import Gate
+
+class GateView(ModelView):
+	model = Gate


### PR DESCRIPTION
In most binder apps we use the user > profile construction.
Profile doesn't have an `id` but uses its foreign key to user as private key.

Binder however tries to filter models on `id` instead of on `pk`.
It also assumes that a foreign key for a one-to-one model is set is set on the root model.
With users and profiles this is not a case as we cannot simply alter the user model.

This PR contains a test for this user profile relation, using the existing zoo model: A gate has a zoo_id as primary key.
It also contains a fix for `pk` filtering instead of `id` filtering and for the foreign key assumption.