### PR TITLE
Split multiput into smaller, reusable functions.

### DIFF
--- a/binder/views.py
+++ b/binder/views.py
@@ -930,11 +930,9 @@ class ModelView(View):
 
 
 
-	def multi_put(self, request):
-		logger.info('ACTIVATING THE MULTI-PUT!!!1!')
-
+	# Put data and with on one big pile, that's easier for us
+	def _multi_put_parse_request(self, request):
 		body = jsonloads(request.body)
-		validation_errors = []
 
 		if not 'data' in body:
 			raise BinderRequestError('missing data')
@@ -945,11 +943,15 @@ class ModelView(View):
 		if 'with' in body and not isinstance(body['with'], dict):
 			raise BinderRequestError('with should be a dict')
 
-		# Put data and with on one big pile, that's easier for us
 		data = body.get('with', {})
 		data[self._model_name()] = body['data']
 
-		# Sort object values by model/id
+		return data
+
+
+
+	# Sort object values by model/id
+	def _multi_put_collect_objects(self, data):
 		objects = {}
 		for modelname, objs in data.items():
 			if not isinstance(objs, list):
@@ -970,7 +972,11 @@ class ModelView(View):
 
 				objects[(model, obj['id'])] = obj
 
-		# Figure out dependencies
+		return objects
+
+
+
+	def _multi_put_calculate_dependencies(self, objects):
 		logger.info('Resolving dependencies for {} objects'.format(len(objects)))
 		dependencies = {}
 		for (model, mid), values in objects.items():
@@ -1004,7 +1010,12 @@ class ModelView(View):
 						if (model, mid) != (r_model, r_id):
 							dependencies[(model, mid)].add((r_model, r_id))
 
-		# Actually sort the objects by dependency (and within dependency layer by model/id)
+		return dependencies
+
+
+
+	# Actually sort the objects by dependency (and within dependency layer by model/id)
+	def _multi_put_order_dependencies(self, dependencies):
 		ordered_objects = []
 		while dependencies:
 			this_batch = []
@@ -1022,7 +1033,13 @@ class ModelView(View):
 				raise BinderRequestError('No progress in dependency resolution! Cyclic dependencies?')
 			ordered_objects += sorted(this_batch, key=lambda obj: (obj[0].__name__, obj[1]))
 
+		return ordered_objects
+
+
+
+	def _multi_put_save_objects(self, ordered_objects, objects, request):
 		new_id_map = {}
+		validation_errors = []
 		for model, oid in ordered_objects:
 			values = objects[(model, oid)]
 			logger.info('Saving {} {}'.format(model.__name__, oid))
@@ -1069,11 +1086,24 @@ class ModelView(View):
 		if validation_errors:
 			raise sum(validation_errors, None)
 
-		bla = defaultdict(list)
-		for (model, oid), nid in new_id_map.items():
-			bla[self.router.model_view(model)()._model_name()].append((oid, nid))
+		return new_id_map
 
-		return JsonResponse({'idmap': bla})
+
+
+	def multi_put(self, request):
+		logger.info('ACTIVATING THE MULTI-PUT!!!1!')
+
+		data = self._multi_put_parse_request(request)
+		objects = self._multi_put_collect_objects(data)
+		dependencies = self._multi_put_calculate_dependencies(objects)
+		ordered_objects = self._multi_put_order_dependencies(dependencies)
+		new_id_map = self._multi_put_save_objects(ordered_objects, objects, request)
+
+		output = defaultdict(list)
+		for (model, oid), nid in new_id_map.items():
+			output[self.router.model_view(model)()._model_name()].append((oid, nid))
+
+		return JsonResponse({'idmap': output})
 
 
 


### PR DESCRIPTION
In TMS we have some dependencies that are unresolvable by multi_put. We need to write some custom code to handle this edge case. Multi_put however currently is request in > response out. For the custom dependency we cannot reuse any of the multi_put code. 

In this pull request we split the multi_put into tinier, reusable and overwritable functions, allowing custom endpoints to reuse request parsing, object collection, dependency calculation, object ordering and id_map constructing.
