### PR TITLE
Add shown properties to model view

### DIFF
--- a/binder/views.py
+++ b/binder/views.py
@@ -79,6 +79,12 @@ class ModelView(View):
 	hidden_fields = []
 	m2m_fields = []
 
+	# Some models have derived properties that are not part of the fields of the model.
+	# Properties added to this shown property list are automatically added to the fields
+	# that are returned. Not that properties added here are read only. They can not be changed
+	# directly. Rather the fields they are derived need to be updated.
+	shown_properties = []
+
 	# Fields that cannot be written (PUT/POST). Writing them is not an error;
 	# their values are silently ignored.
 	# The following fields are always excluded for writes:
@@ -266,6 +272,10 @@ class ModelView(View):
 						data[f.name] = None
 				else:
 					data[f.name] = getattr(obj, f.attname)
+
+			for property in self.shown_properties:
+				data[property] = getattr(obj, property)
+
 			for field, idmap in m2m_ids.items():
 				# TODO: Don't require OneToOneFields in the m2m_fields list
 				if isinstance(self.model._meta.get_field(field), models.OneToOneRel):

--- a/binder/views.py
+++ b/binder/views.py
@@ -81,8 +81,8 @@ class ModelView(View):
 
 	# Some models have derived properties that are not part of the fields of the model.
 	# Properties added to this shown property list are automatically added to the fields
-	# that are returned. Not that properties added here are read only. They can not be changed
-	# directly. Rather the fields they are derived need to be updated.
+	# that are returned. Note that properties added here are read only. They can not be changed
+	# directly. Rather the fields they are derived from need to be updated.
 	shown_properties = []
 
 	# Fields that cannot be written (PUT/POST). Writing them is not an error;
@@ -273,8 +273,8 @@ class ModelView(View):
 				else:
 					data[f.name] = getattr(obj, f.attname)
 
-			for property in self.shown_properties:
-				data[property] = getattr(obj, property)
+			for prop in self.shown_properties:
+				data[prop] = getattr(obj, prop)
 
 			for field, idmap in m2m_ids.items():
 				# TODO: Don't require OneToOneFields in the m2m_fields list

--- a/tests/test_model_view_basics.py
+++ b/tests/test_model_view_basics.py
@@ -53,6 +53,33 @@ class ModelViewBasicsTest(TestCase):
 		result = jsonloads(response.content)
 		self.assertEqual('NotFound', result['code'])
 
+	def test_get_model_shown_properties(self):
+		"""
+		Test that the properties under shown_properties are added to the result of a get model request
+		"""
+		gaia = Zoo(name='GaiaZOO')
+		gaia.full_clean()
+		gaia.save()
+
+		response = self.client.get('/zoo/{}/'.format(gaia.id))
+
+		self.assertEqual(response.status_code, 200)
+		result = jsonloads(response.content)
+
+		self.assertTrue('animal_count' in result['data'])
+		self.assertEqual(0, result['data']['animal_count'])
+
+		coyote = Animal(name='Wile E. Coyote', zoo=gaia)
+		coyote.full_clean()
+		coyote.save()
+
+		response = self.client.get('/zoo/{}/'.format(gaia.id))
+
+		self.assertEqual(response.status_code, 200)
+		result = jsonloads(response.content)
+
+		self.assertTrue('animal_count' in result['data'])
+		self.assertEqual(1, result['data']['animal_count'])
 
 	def test_get_collection_with_no_models_returns_empty_array(self):
 		response = self.client.get('/animal/')
@@ -523,3 +550,5 @@ class ModelViewBasicsTest(TestCase):
 		self.assertEqual(response.status_code, 200)
 		result = jsonloads(response.content)
 		self.assertEqual(1, len(result['_meta']['with']['zoo']))
+
+

--- a/tests/testapp/models/zoo.py
+++ b/tests/testapp/models/zoo.py
@@ -25,4 +25,10 @@ class Zoo(BinderModel):
 	def __str__(self):
 		return 'zoo %d: %s' % (self.pk or 0, self.name)
 
+	@property
+	def animal_count(self):
+		return self.animals.count()
+
+
 post_delete.connect(delete_files, sender=Zoo)
+

--- a/tests/testapp/views/zoo.py
+++ b/tests/testapp/views/zoo.py
@@ -7,3 +7,4 @@ class ZooView(ModelView):
 	m2m_fields = ['animals', 'contacts', 'zoo_employees']
 	model = Zoo
 	file_fields = ['floor_plan']
+	shown_properties = ['animal_count']


### PR DESCRIPTION
This pull requests add a option named `shown_properties` to the model view

In SMS we have many places where models have derived properties from other models. These derived properties can not be added to the response generated by default. At this moment there is a very slow hack to still add these  properties. This pull request will make a much faster way to add this properties to the model. 

An example of a use case:
- We have a zoo inspector, who can see certain features of the zoo. One of such features is that they can see the amount of animals belonging to the zoo
- The zoo inspector is not allowed to see the individual animals
- A solution is to keep a counter of the amount of animals in the zoo. This needs a lot of accounting to keep it correct
- Another solution is to fetch the animals, and do a count on them. This would require the zoo keeper to see too much information
- Therefore, the best solution is to add it as property to the zoo model. 

