### PR TITLE
Relation filtering

### DIFF
--- a/binder/tests/test_filterable_relations.py
+++ b/binder/tests/test_filterable_relations.py
@@ -239,3 +239,60 @@ class WithFilterTest(TestCase):
 			},
 			EXTRA(): None,
 		})
+
+
+
+	def test_where_complains_on_syntax_error(self):
+		res = self.client.get('/zoo/', data={
+			'where': 'contacts'
+		})
+		self.assertEqual(res.status_code, 418)
+		res = jsonloads(res.content)
+
+		assert_json(res, {
+			'message': 'Syntax error in {where=contacts}.',
+			EXTRA(): None,
+		})
+
+
+
+	def test_where_complains_on_nonexistent_relation(self):
+		res = self.client.get('/zoo/', data={
+			'where': 'foo(bar=5)'
+		})
+		self.assertEqual(res.status_code, 418)
+		res = jsonloads(res.content)
+
+		assert_json(res, {
+			'message': 'Unknown field {Zoo}.{foo}.',
+			EXTRA(): None,
+		})
+
+
+
+	def test_where_complains_on_non_relation_field(self):
+		res = self.client.get('/zoo/', data={
+			'where': 'floor_plan(foo=5)'
+		})
+		self.assertEqual(res.status_code, 418)
+		res = jsonloads(res.content)
+
+		assert_json(res, {
+			'message': 'Field is not a related object {Zoo}.{floor_plan}.',
+			EXTRA(): None,
+		})
+
+
+
+	def test_where_complains_on_invalid_value(self):
+		res = self.client.get('/zoo/', data={
+			'with': 'contacts',
+			'where': 'contacts(id=foo)'
+		})
+		self.assertEqual(res.status_code, 418)
+		res = jsonloads(res.content)
+
+		assert_json(res, {
+			'message': 'Invalid value {foo} for AutoField {ContactPerson}.{id}.',
+			EXTRA(): None,
+		})

--- a/binder/tests/test_filterable_relations.py
+++ b/binder/tests/test_filterable_relations.py
@@ -296,3 +296,38 @@ class WithFilterTest(TestCase):
 			'message': 'Invalid value {foo} for AutoField {ContactPerson}.{id}.',
 			EXTRA(): None,
 		})
+
+
+
+	def test_where_handles_missing_close_parens(self):
+		zoo = Zoo(name='Assen')
+		zoo.save()
+		cp1 = ContactPerson(name='henk')
+		cp1.save()
+		zoo.contacts.set([cp1])
+
+		res = self.client.get('/zoo/', data={
+			'with': 'contacts',
+			'where': 'contacts(name=henk'
+		})
+		self.assertEqual(res.status_code, 200)
+		res = jsonloads(res.content)
+
+		assert_json(res, {
+			'data': [
+				{
+					'id': zoo.id,
+					'contacts': [cp1.id],
+					EXTRA(): None,
+				}
+			],
+			'with': {
+				'contact_person': [
+					{
+						'id': cp1.id,
+						EXTRA(): None,
+					},
+				]
+			},
+			EXTRA(): None,
+		})

--- a/binder/tests/test_filterable_relations.py
+++ b/binder/tests/test_filterable_relations.py
@@ -256,15 +256,15 @@ class WithFilterTest(TestCase):
 
 
 
-	def test_where_complains_on_nonexistent_relation(self):
+	def test_where_complains_if_relation_not_in_with(self):
 		res = self.client.get('/zoo/', data={
-			'where': 'foo(bar=5)'
+			'where': 'contacts(name:startswith=he)'
 		})
 		self.assertEqual(res.status_code, 418)
 		res = jsonloads(res.content)
 
 		assert_json(res, {
-			'message': 'Unknown field {Zoo}.{foo}.',
+			'message': 'Relation of {where=contacts(name:startswith=he)} is missing from withs.',
 			EXTRA(): None,
 		})
 
@@ -272,6 +272,7 @@ class WithFilterTest(TestCase):
 
 	def test_where_complains_on_non_relation_field(self):
 		res = self.client.get('/zoo/', data={
+			'with': 'floor_plan',
 			'where': 'floor_plan(foo=5)'
 		})
 		self.assertEqual(res.status_code, 418)
@@ -310,24 +311,11 @@ class WithFilterTest(TestCase):
 			'with': 'contacts',
 			'where': 'contacts(name=henk'
 		})
-		self.assertEqual(res.status_code, 200)
+
+		self.assertEqual(res.status_code, 418)
 		res = jsonloads(res.content)
 
 		assert_json(res, {
-			'data': [
-				{
-					'id': zoo.id,
-					'contacts': [cp1.id],
-					EXTRA(): None,
-				}
-			],
-			'with': {
-				'contact_person': [
-					{
-						'id': cp1.id,
-						EXTRA(): None,
-					},
-				]
-			},
+			'message': 'Syntax error in {where=contacts(name=henk}.',
 			EXTRA(): None,
 		})

--- a/binder/tests/test_filterable_relations.py
+++ b/binder/tests/test_filterable_relations.py
@@ -3,9 +3,8 @@ from django.contrib.auth.models import User
 
 from binder.json import jsonloads
 
-from .testapp.models import Animal, Costume, Zoo, Caretaker, Gate
+from .testapp.models import Animal, Zoo, Caretaker
 from .compare import assert_json, EXTRA
-import json
 
 class WithFilterTest(TestCase):
 	def setUp(self):
@@ -48,7 +47,6 @@ class WithFilterTest(TestCase):
 		self.assertEqual(res.status_code, 200)
 		res = jsonloads(res.content)
 
-		from pudb import set_trace; set_trace()
 		assert_json(res, {
 			'data': [
 				{

--- a/binder/tests/test_filterable_relations.py
+++ b/binder/tests/test_filterable_relations.py
@@ -1,0 +1,79 @@
+from django.test import TestCase, Client
+from django.contrib.auth.models import User
+
+from binder.json import jsonloads
+
+from .testapp.models import Animal, Costume, Zoo, Caretaker, Gate
+from .compare import assert_json, EXTRA
+import json
+
+class WithFilterTest(TestCase):
+	def setUp(self):
+		super().setUp()
+		u = User(username='testuser', is_active=True, is_superuser=True)
+		u.set_password('test')
+		u.save()
+		self.client = Client()
+		r = self.client.login(username='testuser', password='test')
+		self.assertTrue(r)
+
+	def test_filter_intermediate_relation(self):
+		zoo = Zoo(name='Meerkerk')
+		zoo.full_clean()
+		zoo.save()
+
+		gman = Caretaker(name='gman')
+		gman.full_clean()
+		gman.save()
+		freeman = Caretaker(name='gordon')
+		freeman.full_clean()
+		freeman.save()
+
+
+		antlion = Animal(zoo=zoo, name='antlion', caretaker=freeman)
+		antlion.full_clean()
+		antlion.save()
+
+		sealion = Animal(zoo=zoo, name='sealion')
+		sealion.full_clean()
+		sealion.save()
+
+		goat = Animal(zoo=zoo, name='goat', caretaker=gman)
+		goat.full_clean()
+		goat.save()
+
+		# Filter the animal relations on animals with lion in the name
+		# This means we don't expect the goat and its caretaker in the with response
+		res = self.client.get('/zoo/', data={'with': 'animals.caretaker', 'where': 'animals(name:contains=lion)'})
+		self.assertEqual(res.status_code, 200)
+		res = jsonloads(res.content)
+
+		from pudb import set_trace; set_trace()
+		assert_json(res, {
+			'data': [
+				{
+					'id': zoo.id,
+					'animals': [antlion.id, sealion.id, goat.id],  # Currently we only filter the withs, not foreign keys
+					EXTRA(): None,
+				}
+			],
+			'with': {
+				'animal': [
+					{
+						'id': antlion.id,
+						EXTRA(): None,
+					},
+					{
+						'id': sealion.id,
+						EXTRA(): None,
+					},
+				],
+				'caretaker': [
+					{
+						'id': freeman.id,
+						EXTRA(): None,
+					},
+				]
+			},
+			EXTRA(): None,
+		})

--- a/binder/views.py
+++ b/binder/views.py
@@ -289,15 +289,44 @@ class ModelView(View):
 	def _get_obj(self, id, request):
 		return self._get_objs(self.model.objects.filter(pk=id), request=request)[0]
 
+	# Split ['animals(name:contains=lion)']
+	# in ['animals': ['name:contains=lion']]
+	# { 'animals': {'filters': ['name:contains=lion'], 'subrels': {}}}
+	#
+	# Please refactor this
+	def _parse_wheres(self, wheres):
+		where_map = {}
+		for wh in wheres:
+			target_rel, query = wh.split('(')
+			# Also strip the trailing ) from the query
+			query = query[:-1]
 
+			rels = target_rel.split('.')
+			pointer = where_map
+			for i, rel in enumerate(rels):
+				if rel not in pointer:
+					pointer[rel] = {'filters': [], 'subrels': {}}
+
+				# Don't change the pointer
+				# if this is the last iteration
+				if i != (len(rels) - 1):
+					pointer = pointer[rel]['subrels']
+
+			pointer[rel]['filters'].append(query)
+
+		return where_map
 
 	# Find which objects of which models to include according to <withs> for the objects in <queryset>.
 	# returns two dictionaries:
 	# - withs: { related_modal_name: [ids]}
 	# - mappings: { with_name: related_model_name}
-	def _get_withs(self, pks, withs, request):
+	def _get_withs(self, pks, withs, request, wheres=None):
 		if withs is None and request is not None:
 			withs = list(filter(None, request.GET.get('with', '').split(',')))
+
+		if wheres is None and request is not None:
+			where_params = list(filter(None, request.GET.get('where', '').split(',')))
+			where_map = self._parse_wheres(where_params)
 
 		if isinstance(pks, django.db.models.query.QuerySet):
 			pks = pks.values_list('pk', flat=True)
@@ -314,7 +343,13 @@ class ModelView(View):
 		extras_mapping = {}
 
 		for w in withs:
-			(view, new_ids) = self._get_with(w, pks, request=request)
+			# Make sure the _get_with only gets the wheres relevant to the relation
+			# We scope on the head of the relation, as the caretakers in animals.caretaker
+			# must also be filtered by the animal filter
+			# head = w.split('.')[0]
+			# scoped_wheres = where_map.get(head, [])
+
+			(view, new_ids) = self._get_with(w, pks, request=request, where_map=where_map)
 			if view:
 				extras_mapping[w] = view
 				extras[view].update(set(new_ids))
@@ -366,22 +401,46 @@ class ModelView(View):
 
 
 
-	def _get_with(self, wth, pks, request):
+	def _get_with(self, wth, pks, request, where_map):
 		head, *tail = wth.split('.')
 
 		next = self._follow_related(head)[0].model
 
-		pks = list(self.model.objects.filter(pk__in=pks).values_list(head + '__pk', flat=True))
+		# _get_with doesn't fully recurse the relation tree
+		# but it lags behind 1 recursion
+		rel_ids = list(self.model.objects.filter(pk__in=pks).values_list(head + '__pk', flat=True))
+		rel_ids = self._filter_relation(next, rel_ids, where_map.get(head, None))
+
 		view_class = self.router.model_view(next)
 
 		if not tail:
-			return (view_class, pks)
+			return (view_class, rel_ids)
 		else:
 			view = view_class()
 			# {router-view-instance}
 			view.router = self.router
-			return view._get_with('.'.join(tail), pks, request=request)
+			wm_scoped = where_map.get(head)
+			wm_scoped = wm_scoped['subrels'] if wm_scoped else {}
+			return view._get_with('.'.join(tail), rel_ids, request, wm_scoped)
 
+
+	# We have a set of ids where model M should be scoped on,
+	# but also a set of wheres where model M should further be scoped on
+	#
+	# Returns a further scoped list of ids
+	def _filter_relation(self, M, ids, where_map):
+		# If there are no filters, return the given ids
+		if where_map is None:
+			return ids
+
+		wheres = where_map['filters']
+
+		qs = M.objects.filter(pk__in=ids)
+		for where in wheres:
+			field, val = where.split('=')
+			qs = self._parse_filter(qs, field, val)
+
+		return qs.values_list('pk', flat=True)
 
 
 	def _parse_filter(self, queryset, field, value, partial=''):
@@ -662,6 +721,7 @@ class ModelView(View):
 		queryset = self._paginate(queryset, request)
 
 		#### with
+		# parse wheres from request
 		extras, extras_mapping = self._get_withs(queryset, withs, request=request)
 
 		data = self._get_objs(queryset, request=request)


### PR DESCRIPTION
Fix for issue #81 

I went with the `?where=contacts.city(name=ehv)` approach instead of the `?.contacts.city(name=ehv)`, as in the latter the query param key would contain the opening `(` and the val would contain the closing `)`.

## Tests:
- where on a 1tomany and a 1to1 relation
- multiple wheres in different levels of the requested relation
- a where and a filter
- where on a manytomany relation

## Room for improvement:
The with tree traversal from binder is really weird. When a with is set to `animals.caretaker`, it calls `_get_with` once for `animals` once for `animals.caretaker` and once for `caretaker`, which means the queryset of the related animals is calculated twice.

Anyhow, for the where calculating I do calculate a proper tree, but the generation of this tree is a bit verbose (in `_parse_wheres`)

Also, the where filter only changes the result of the with. If a relation falls outside of the scope of the `where`, the fk of that relation stays intact, it just isn't featured in the with. This is because in binder the foreign key (or m2m map) calculation is done one or more times in _get_with, and once in _get_objs using entirely seperate implementations.


 