### PR TITLE
Disable searching on hidden fields

### DIFF
--- a/binder/tests/test_hidden_fields.py
+++ b/binder/tests/test_hidden_fields.py
@@ -1,0 +1,78 @@
+from django.test import TestCase, Client
+from .testapp.models import Caretaker
+from django.contrib.auth.models import User
+
+from binder.json import jsonloads
+
+
+class HiddenFieldTest(TestCase):
+	def setUp(self):
+		super().setUp()
+		u = User(username='testuser', is_active=True, is_superuser=True)
+		u.set_password('test')
+		u.save()
+		self.client = Client()
+		r = self.client.login(username='testuser', password='test')
+		self.assertTrue(r)
+
+		self.secret_caretaker = Caretaker(
+			name='C.A.R.E Taker',
+			ssn='1234'
+		)
+		self.secret_caretaker.save()
+
+		self.other_secret_caretaker = Caretaker(
+			name='C.A.R.E Taker2',
+			ssn='5678'
+		)
+		self.other_secret_caretaker.save()
+
+
+
+	def test_get_caretaker_doesnt_return_ssn(self):
+		"""
+		The SSN is a hidden field for a caretaker. Make sure it is not returned on a get request
+		"""
+		# Filter the animal relations on animals with lion in the name
+		# This means we don't expect the goat and its caretaker in the with response
+		res = self.client.get('/caretaker/{}/'.format(self.secret_caretaker.id), data={})
+		self.assertEqual(res.status_code, 200)
+		res = jsonloads(res.content)
+
+		# Make sure the ssn is not in the dataset
+		self.assertNotIn('ssn', res['data'])
+
+
+	def test_filtering_on_ssn_is_ignored(self):
+		"""
+		Make sure that filtering on hidden fields is ignored, otherwise it may leak information stored in
+		hidden fields by doing a smart lookup
+		"""
+		res = self.client.get('/caretaker/', data={})
+		self.assertEqual(res.status_code, 200)
+		res = jsonloads(res.content)
+
+		# No filtering, every records is returned
+		self.assertEqual(2, res['meta']['total_records'])
+		self.assertEqual(2, len(res['data']))
+
+		# A normal where is filter
+		res = self.client.get('/caretaker/', data={
+			'.ssn': 1234
+		})
+
+		self.assertEqual(res.status_code, 200)
+		res = jsonloads(res.content)
+		# Filtering should be ignored,
+		self.assertEqual(2, res['meta']['total_records'])
+		self.assertEqual(2, len(res['data']))
+
+		# A more complicated filter
+		res = self.client.get('/caretaker/', data={
+			'ssn:startswith': '1234'
+		})
+		self.assertEqual(res.status_code, 200)
+		res = jsonloads(res.content)
+		# Filtering should be ignored,
+		self.assertEqual(2, res['meta']['total_records'])
+		self.assertEqual(2, len(res['data']))

--- a/binder/tests/test_history.py
+++ b/binder/tests/test_history.py
@@ -84,7 +84,7 @@ class HistoryTest(TestCase):
 
 
 	def test_model_with_related_history_model_creates_changes_on_the_same_changeset(self):
-		mickey = Caretaker(name='Mickey')
+		mickey = Caretaker(name='Mickey', ssn='mouse_1234')
 		mickey.full_clean()
 		mickey.save()
 		pluto = Animal(name='Pluto')

--- a/binder/tests/test_model_view_basics.py
+++ b/binder/tests/test_model_view_basics.py
@@ -368,7 +368,7 @@ class ModelViewBasicsTest(TestCase):
 		gaia.full_clean()
 		gaia.save()
 
-		fabbby = Caretaker(name='fabbby')
+		fabbby = Caretaker(name='fabbby', ssn='1234')
 		fabbby.full_clean()
 		fabbby.save()
 

--- a/binder/tests/testapp/models/caretaker.py
+++ b/binder/tests/testapp/models/caretaker.py
@@ -5,6 +5,10 @@ class Caretaker(BinderModel):
 	name = models.TextField()
 	last_seen = models.DateTimeField(null=True, blank=True)
 
+	# We have the ssn for each caretaker. We have to make sure that nobody can access this ssn in anyway, since
+	# this shouldn't be accessible
+	ssn = models.TextField(default='my secret ssn')
+
 	def __str__(self):
 		return 'caretaker %d: %s' % (self.pk, self.name)
 

--- a/binder/tests/testapp/views/caretaker.py
+++ b/binder/tests/testapp/views/caretaker.py
@@ -3,4 +3,5 @@ from binder.views import ModelView
 from ..models import Caretaker
 
 class CaretakerView(ModelView):
+	hidden_fields = ['ssn']
 	model = Caretaker

--- a/binder/views.py
+++ b/binder/views.py
@@ -447,6 +447,7 @@ class ModelView(View):
 		rel_ids = list(self.model.objects.filter(pk__in=pks).values_list(head + '__pk', flat=True))
 
 		view_class = self.router.model_view(next)
+		view_class.router = self.router
 		rel_ids = view_class()._filter_relation(next, rel_ids, where_map.get(head, None))
 
 		if not tail:
@@ -474,6 +475,7 @@ class ModelView(View):
 		qs = M.objects.filter(pk__in=ids)
 		for where in wheres:
 			field, val = where.split('=')
+
 			qs = self._parse_filter(qs, field, val)
 
 		return qs.values_list('pk', flat=True)
@@ -482,11 +484,20 @@ class ModelView(View):
 	def _parse_filter(self, queryset, field, value, partial=''):
 		head, *tail = field.split('.')
 
+		view = self.router.model_view(self.model)
+		# Take the real field part form the field
+		real_field = field.split(':')[0] if ':' in field else field
+		# Check for all the wheres, if the field we are filtering on is hidden. If so, we ignore the filtering. This
+		# makes sure that filtering can't be used for leaking data
+		if real_field in view.hidden_fields:
+			return queryset
+
 		if tail:
 			next = self._follow_related(head)[0].model
 			view = self.router.model_view(next)()
 			# {router-view-instance}
 			view.router = self.router
+
 			return view._parse_filter(queryset, '.'.join(tail), value, partial + head + '__')
 
 		invert = False


### PR DESCRIPTION
At this moment it is possible to get information from hidden fields by doing searching. This PR disables any searching on hidden fields (These searches are now ignored)

This shouldn't be a backwards compatibility break. Only thing that I can think of that might break is if the frontend specifically depends on hidden fields. If this is the case, somebody made a terrible architectural decision, which they should fix. 