### PR TITLE
Support model inheritance in multiput

### DIFF
--- a/binder/tests/test_inheritance.py
+++ b/binder/tests/test_inheritance.py
@@ -1,8 +1,6 @@
 import json
 
 from django.test import TestCase, Client
-
-from binder.json import jsonloads
 from django.contrib.auth.models import User
 
 from .testapp.models import Zoo

--- a/binder/tests/test_inheritance.py
+++ b/binder/tests/test_inheritance.py
@@ -1,0 +1,66 @@
+import json
+
+from django.test import TestCase, Client
+
+from binder.json import jsonloads
+from django.contrib.auth.models import User
+
+from .testapp.models import Zoo
+
+
+class InheritanceTest(TestCase):
+
+	def setUp(self):
+		super().setUp()
+		u = User(username='testuser', is_active=True, is_superuser=True)
+		u.set_password('test')
+		u.save()
+		self.client = Client()
+		r = self.client.login(username='testuser', password='test')
+		self.assertTrue(r)
+
+	def test_add_lion_to_zoo(self):
+		zoo = Zoo(name='Artis')
+		zoo.save()
+
+		response = self.client.put(
+			'/zoo/',
+			content_type='application/json',
+			data=json.dumps({
+				'data': [
+					{
+						'id': zoo.pk,
+						'animals': [-1, -2],
+					},
+				],
+				'with': {
+					'lion': [
+						{
+							'id': -1,
+							'name': 'Mufasa',
+							'mane_magnificence': 10,
+						},
+						{
+							'id': -2,
+							'name': 'Scar',
+							'mane_magnificence': 4,
+						},
+					],
+				},
+			}),
+		)
+		if (response.status_code != 200):
+			print(response.content)
+		self.assertEqual(response.status_code, 200)
+
+		zoo.refresh_from_db()
+		animals = list(zoo.animals.all())
+		self.assertEqual(len(animals), 2)
+		mane_magnificence_map = {
+			animal.name: animal.lion.mane_magnificence
+			for animal in animals
+		}
+		self.assertEqual(mane_magnificence_map, {
+			'Mufasa': 10,
+			'Scar': 4,
+		})

--- a/binder/tests/testapp/models/__init__.py
+++ b/binder/tests/testapp/models/__init__.py
@@ -7,5 +7,6 @@ from .contact_person import ContactPerson
 from .costume import Costume
 from .feeding_schedule import FeedingSchedule
 from .gate import Gate
+from .lion import Lion
 from .zoo import Zoo
 from .zoo_employee import ZooEmployee

--- a/binder/tests/testapp/models/lion.py
+++ b/binder/tests/testapp/models/lion.py
@@ -1,0 +1,8 @@
+from django.db import models
+
+from .animal import Animal
+
+
+class Lion(Animal):
+
+	mane_magnificence = models.SmallIntegerField()

--- a/binder/tests/testapp/views/__init__.py
+++ b/binder/tests/testapp/views/__init__.py
@@ -7,5 +7,6 @@ from .contact_person import ContactPersonView
 from .costume import CostumeView
 from .feeding_schedule import FeedingScheduleView
 from .gate import GateView
+from .lion import Lion
 from .zoo import ZooView
 from .zoo_employee import ZooEmployeeView

--- a/binder/tests/testapp/views/lion.py
+++ b/binder/tests/testapp/views/lion.py
@@ -1,0 +1,6 @@
+from binder.views import ModelView
+
+from ..models import Lion
+
+class LionView(ModelView):
+	model = Lion

--- a/binder/views.py
+++ b/binder/views.py
@@ -1215,7 +1215,7 @@ class ModelView(View):
 					if not (
 						hasattr(base, 'Meta') and
 						getattr(base.Meta, 'abstract', False)
-					) and BinderModel in getmro(base)[1:]:
+					) and isinstance(base, BinderModel):
 						new_id_map[(base, oid)] = obj.id
 				logger.info('Saved as id {}'.format(obj.id))
 


### PR DESCRIPTION
Makes the whole negative id relation magic work for models with inheritance by also setting backrefs for subclasses of models and also saving negative ids for superclasses of created models.