### PR TITLE
Non int pk router support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ venv
 *.pyc
 .tox/
 .vscode/
+**/*.swp

--- a/binder/classproperty.py
+++ b/binder/classproperty.py
@@ -1,0 +1,18 @@
+class classproperty:
+	"""
+	Simple implementation for a classproperty decorator. Does not support
+	setters.
+	"""
+
+	def __init__(self, func):
+		if not isinstance(func, (classmethod, staticmethod)):
+			func = classmethod(func)
+		self.func = func
+
+	def __get__(self, obj, cls=None):
+		if cls is None:
+			cls = type(obj)
+		return self.func.__get__(obj, cls)()
+
+	def __set__(self, obj, value):
+		raise AttributeError('can\'t set classproperty')

--- a/binder/permissions/views.py
+++ b/binder/permissions/views.py
@@ -152,7 +152,7 @@ class PermissionView(ModelView):
 
 	def dispatch_file_field(self, request, pk=None, file_field=None):
 		try:
-			obj = self.get_queryset(request).get(pk=self.route_pk_parser(pk))
+			obj = self.get_queryset(request).get(pk=self.pk_parser(pk))
 		except ObjectDoesNotExist:
 			raise BinderNotFound()
 

--- a/binder/permissions/views.py
+++ b/binder/permissions/views.py
@@ -152,7 +152,7 @@ class PermissionView(ModelView):
 
 	def dispatch_file_field(self, request, pk=None, file_field=None):
 		try:
-			obj = self.get_queryset(request).get(pk=int(pk))
+			obj = self.get_queryset(request).get(pk=self.route_pk_parser(pk))
 		except ObjectDoesNotExist:
 			raise BinderNotFound()
 

--- a/binder/router.py
+++ b/binder/router.py
@@ -153,7 +153,7 @@ class Router(object):
 						urls.append(django.conf.urls.url(r'^{}/(?P<pk>{})/{}/{}$'.format(route.route, view.pk_regex, route_name, extra),
 								view.as_view(), kwargs, name='{}.{}'.format(name, route_name)))
 					if hasattr(method, 'list_route'):
-						urls.append(django.conf.urls.url(r'^{}/{}/{}$'.format(route.route, view.pk_regex, route_name, extra),
+						urls.append(django.conf.urls.url(r'^{}/{}/{}$'.format(route.route, route_name, extra),
 								view.as_view(), kwargs, name='{}.{}'.format(name, route_name)))
 
 		return urls

--- a/binder/router.py
+++ b/binder/router.py
@@ -128,16 +128,16 @@ class Router(object):
 			if route.list_endpoint:
 				urls.append(django.conf.urls.url(r'^{}/$'.format(route.route), view.as_view(), {'router': self}, name=name))
 			if route.detail_endpoint:
-				urls.append(django.conf.urls.url(r'^{}/(?P<pk>{})/$'.format(route.route, view.route_pk_re), view.as_view(), {'router': self}, name=name))
+				urls.append(django.conf.urls.url(r'^{}/(?P<pk>{})/$'.format(route.route, view.pk_regex), view.as_view(), {'router': self}, name=name))
 
 			# History views
 			if view.model and hasattr(view.model, 'Binder') and view.model.Binder.history:
-				urls.append(django.conf.urls.url(r'^{}/(?P<pk>{})/history/$'.format(route.route, view.route_pk_re), view.as_view(), {'history': 'normal', 'router': self}, name=name))
-				urls.append(django.conf.urls.url(r'^{}/(?P<pk>{})/history/debug/$'.format(route.route, view.route_pk_re), view.as_view(), {'history': 'debug', 'router': self}, name=name))
+				urls.append(django.conf.urls.url(r'^{}/(?P<pk>{})/history/$'.format(route.route, view.pk_regex), view.as_view(), {'history': 'normal', 'router': self}, name=name))
+				urls.append(django.conf.urls.url(r'^{}/(?P<pk>{})/history/debug/$'.format(route.route, view.pk_regex), view.as_view(), {'history': 'debug', 'router': self}, name=name))
 
 			# File field endpoints
 			for ff in view.file_fields:
-				urls.append(django.conf.urls.url(r'^{}/(?P<pk>{})/{}/$'.format(route.route, view.route_pk_re, ff),
+				urls.append(django.conf.urls.url(r'^{}/(?P<pk>{})/{}/$'.format(route.route, view.pk_regex, ff),
 						view.as_view(), {'file_field': ff, 'router': self}, name='{}.{}'.format(name, ff)))
 
 			# Custom endpoints
@@ -150,10 +150,10 @@ class Router(object):
 					if method.unauthenticated:
 						kwargs['unauthenticated'] = True
 					if hasattr(method, 'detail_route'):
-						urls.append(django.conf.urls.url(r'^{}/(?P<pk>{})/{}/{}$'.format(route.route, view.route_pk_re, route_name, extra),
+						urls.append(django.conf.urls.url(r'^{}/(?P<pk>{})/{}/{}$'.format(route.route, view.pk_regex, route_name, extra),
 								view.as_view(), kwargs, name='{}.{}'.format(name, route_name)))
 					if hasattr(method, 'list_route'):
-						urls.append(django.conf.urls.url(r'^{}/{}/{}$'.format(route.route, view.route_pk_re, route_name, extra),
+						urls.append(django.conf.urls.url(r'^{}/{}/{}$'.format(route.route, view.pk_regex, route_name, extra),
 								view.as_view(), kwargs, name='{}.{}'.format(name, route_name)))
 
 		return urls

--- a/binder/router.py
+++ b/binder/router.py
@@ -128,16 +128,16 @@ class Router(object):
 			if route.list_endpoint:
 				urls.append(django.conf.urls.url(r'^{}/$'.format(route.route), view.as_view(), {'router': self}, name=name))
 			if route.detail_endpoint:
-				urls.append(django.conf.urls.url(r'^{}/(?P<pk>[0-9]+)/$'.format(route.route), view.as_view(), {'router': self}, name=name))
+				urls.append(django.conf.urls.url(r'^{}/(?P<pk>{})/$'.format(route.route, view.route_pk_re), view.as_view(), {'router': self}, name=name))
 
 			# History views
 			if view.model and hasattr(view.model, 'Binder') and view.model.Binder.history:
-				urls.append(django.conf.urls.url(r'^{}/(?P<pk>[0-9]+)/history/$'.format(route.route), view.as_view(), {'history': 'normal', 'router': self}, name=name))
-				urls.append(django.conf.urls.url(r'^{}/(?P<pk>[0-9]+)/history/debug/$'.format(route.route), view.as_view(), {'history': 'debug', 'router': self}, name=name))
+				urls.append(django.conf.urls.url(r'^{}/(?P<pk>{})/history/$'.format(route.route, view.route_pk_re), view.as_view(), {'history': 'normal', 'router': self}, name=name))
+				urls.append(django.conf.urls.url(r'^{}/(?P<pk>{})/history/debug/$'.format(route.route, view.route_pk_re), view.as_view(), {'history': 'debug', 'router': self}, name=name))
 
 			# File field endpoints
 			for ff in view.file_fields:
-				urls.append(django.conf.urls.url(r'^{}/(?P<pk>[0-9]+)/{}/$'.format(route.route, ff),
+				urls.append(django.conf.urls.url(r'^{}/(?P<pk>{})/{}/$'.format(route.route, view.route_pk_re, ff),
 						view.as_view(), {'file_field': ff, 'router': self}, name='{}.{}'.format(name, ff)))
 
 			# Custom endpoints
@@ -150,10 +150,10 @@ class Router(object):
 					if method.unauthenticated:
 						kwargs['unauthenticated'] = True
 					if hasattr(method, 'detail_route'):
-						urls.append(django.conf.urls.url(r'^{}/(?P<pk>[0-9]+)/{}/{}$'.format(route.route, route_name, extra),
+						urls.append(django.conf.urls.url(r'^{}/(?P<pk>{})/{}/{}$'.format(route.route, view.route_pk_re, route_name, extra),
 								view.as_view(), kwargs, name='{}.{}'.format(name, route_name)))
 					if hasattr(method, 'list_route'):
-						urls.append(django.conf.urls.url(r'^{}/{}/{}$'.format(route.route, route_name, extra),
+						urls.append(django.conf.urls.url(r'^{}/{}/{}$'.format(route.route, view.route_pk_re, route_name, extra),
 								view.as_view(), kwargs, name='{}.{}'.format(name, route_name)))
 
 		return urls

--- a/binder/tests/test_router.py
+++ b/binder/tests/test_router.py
@@ -1,3 +1,5 @@
+import re
+
 from django.test import TestCase
 from binder.models import BinderModel
 from binder.router import Router, Route
@@ -121,3 +123,38 @@ class RouterTest(TestCase):
 
 		self.assertTrue(is_valid_path('/bar/', urls_module))
 		self.assertFalse(is_valid_path('/bar/1/', urls_module))
+
+
+	def test_register_view_custom_pk_re(self):
+
+		class ParentView(ModelView):
+			pass
+
+		class FooView(ParentView):
+			model = FooModel
+			route = 'foo'
+			route_pk_re = r'foo|bar|baz'
+
+		r = Router()
+		r.register(ParentView)
+		urls_module.urlpatterns = [url(r'^', include(r.urls))]
+
+		self.assertTrue(is_valid_path('/foo/', urls_module))
+
+		self.assertTrue(is_valid_path('/foo/foo/', urls_module))
+		self.assertTrue(is_valid_path('/foo/bar/', urls_module))
+		self.assertTrue(is_valid_path('/foo/baz/', urls_module))
+
+		self.assertFalse(is_valid_path('/foo/1/', urls_module))
+		self.assertFalse(is_valid_path('/foo/12345/', urls_module))
+		self.assertFalse(is_valid_path('/foo/blaat/', urls_module))
+
+		self.assertFalse(is_valid_path('/bar/', urls_module))
+
+		self.assertFalse(is_valid_path('/bar/foo/', urls_module))
+		self.assertFalse(is_valid_path('/bar/bar/', urls_module))
+		self.assertFalse(is_valid_path('/bar/baz/', urls_module))
+
+		self.assertFalse(is_valid_path('/bar/1/', urls_module))
+		self.assertFalse(is_valid_path('/bar/12345/', urls_module))
+		self.assertFalse(is_valid_path('/bar/blaat/', urls_module))

--- a/binder/tests/test_router.py
+++ b/binder/tests/test_router.py
@@ -1,5 +1,3 @@
-import re
-
 from django.test import TestCase
 from binder.models import BinderModel
 from binder.router import Router, Route

--- a/binder/views.py
+++ b/binder/views.py
@@ -96,6 +96,12 @@ class ModelView(View):
 	# If None, doesn't add a route.
 	route = True
 
+	# The regex used to match the pk for detail endpoints
+	route_pk_re = r'\d+'
+
+	# The parser used to transform the str of the matched pk to the right value
+	route_pk_parser = int
+
 	# What regular fields and FKs show up in a GET is controlled by
 	# shown_fields and hidden_fields. If shown_fields is a list of fields,
 	# only those fields are included in a GET. If shown_fields is None, all
@@ -694,7 +700,7 @@ class ModelView(View):
 		meta = {}
 		queryset = self.get_queryset(request)
 		if pk:
-			queryset = queryset.filter(pk=int(pk))
+			queryset = queryset.filter(pk=self.route_pk_parser(pk))
 
 		# No parameter repetition. Should be extended to .params too after filters have been refactored.
 		for k, v in request.GET.lists():
@@ -1253,9 +1259,9 @@ class ModelView(View):
 		values = jsonloads(request.body)
 
 		try:
-			obj = self.get_queryset(request).select_for_update().get(pk=int(pk))
+			obj = self.get_queryset(request).select_for_update().get(pk=self.route_pk_parser(pk))
 			# Permission checks are done at this point, so we can avoid get_queryset()
-			old = self._get_objs(self.model.objects.filter(pk=int(pk)), request)[0]
+			old = self._get_objs(self.model.objects.filter(pk=self.route_pk_parser(pk)), request)[0]
 		except ObjectDoesNotExist:
 			raise BinderNotFound()
 
@@ -1323,7 +1329,7 @@ class ModelView(View):
 			pass
 
 		try:
-			obj = self.get_queryset(request).select_for_update().get(pk=int(pk))
+			obj = self.get_queryset(request).select_for_update().get(pk=self.route_pk_parser(pk))
 		except ObjectDoesNotExist:
 			raise BinderNotFound()
 
@@ -1377,7 +1383,7 @@ class ModelView(View):
 			pk = obj.pk
 		else:
 			try:
-				obj = self.get_queryset(request).get(pk=int(pk))
+				obj = self.get_queryset(request).get(pk=self.route_pk_parser(pk))
 			except ObjectDoesNotExist:
 				raise BinderNotFound()
 

--- a/binder/views.py
+++ b/binder/views.py
@@ -33,7 +33,7 @@ def resolve_regex(field):
 		return r'\d+'
 	elif isinstance(field, models.SlugField):
 		return r'[-a-zA-Z0-9_]+'
-	elif isinstance(field, models.ForeignKey) and len(field.to_fields) == 1:
+	elif isinstance(field, models.ForeignKey):
 		return resolve_regex(field.target_field)
 	else:
 		raise ValueError(
@@ -47,7 +47,7 @@ def resolve_parser(field):
 		return int
 	elif isinstance(field, models.SlugField):
 		return str
-	elif isinstance(field, models.ForeignKey) and len(field.to_fields) == 1:
+	elif isinstance(field, models.ForeignKey):
 		return resolve_parser(field.target_field)
 	else:
 		raise ValueError(


### PR DESCRIPTION
Adds support for routing with non int pks, I don't know how well the rest of binder has support for non int pks so probably a very experimental feature. But it shouldn't break any existing functionality.