### PR TITLE
Delete scopes fix

### DIFF
--- a/binder/permissions/views.py
+++ b/binder/permissions/views.py
@@ -327,11 +327,8 @@ class PermissionView(ModelView):
 			except Exception as e:
 				# Call with queryset instead of object for backwards compat
 				try:
-					scope = scope_func(
-						request,
-						type(object).objects.filter(pk=object.pk),
-						values,
-					)
+					qs = self.get_queryset(request).filter(pk=object.pk)
+					scope = scope_func(request, qs, values)
 				except Exception:
 					# Both failed so exception probably was not related to
 					# instance vs queryset so raise original exception


### PR DESCRIPTION
For some weird reason delete scopes got a queryset containing exactly one instance instead of just that instance like change and add scopes get. This has however been in binder for so long now that we have loads of projects that actually depend on this now. This PR tries to be as backwards compatible as possibly by first trying to call the method with the instance and when that raises an exception trying it with a queryset.

The only case where this is non backwards compatible if we somehow have a delete scope somewhere that will not raise an exception when given an instance but produces a different value then when it is a queryset. This case seems highly unlikely too me.

Since the whole permission view stuff is barely tested I also ran the SMS test suite with this branch as installed and that goes fine (Just shows a few warnings about delete scopes still working with querysets which is actually a good thing since it shows the backwards compatibility working.)