### PR TITLE
Add automated test discoverer to binder

### DIFF
--- a/binder/.flake8
+++ b/binder/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = W191,E501,E301,E302,E303,E265,E201,E202,E713,E126,E128,E226,E221,E266,E127,E251,E305,E241,E272,E261
+ignore = W191,E501,E301,E302,E303,E265,E201,E202,E713,E126,E128,E226,E221,E266,E127,E251,E305,E241,E272,E261,W504
 
 # W191            indentation uses tabs
 # E501            line too long
@@ -17,3 +17,4 @@ ignore = W191,E501,E301,E302,E303,E265,E201,E202,E713,E126,E128,E226,E221,E266,E
 # E241            multiple spaces after ':'
 # E272            multiple spaces before keyword
 # E261            at least two spaces before inline comment
+# W504            line break after binary operator

--- a/binder/__init__.py
+++ b/binder/__init__.py
@@ -1,1 +1,2 @@
+# flake8: noqa
 from .tests_discoverer import load_tests

--- a/binder/__init__.py
+++ b/binder/__init__.py
@@ -1,0 +1,1 @@
+from .tests_discoverer import load_tests

--- a/binder/plugins/token_auth/management/commands/create_user_token.py
+++ b/binder/plugins/token_auth/management/commands/create_user_token.py
@@ -1,0 +1,30 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.utils.translation import ugettext as _
+from django.contrib.auth.models import User
+from django.db import transaction
+
+from binder.plugins.token_auth.models import Token
+
+class Command(BaseCommand):
+	help = _('Create a fresh token for the given user')
+
+	def add_arguments(self, parser):
+		parser.add_argument('username', type=str)
+		parser.add_argument('-k', '--keep-existing', action='store_true', help='Keep existing tokens (by default, the new token will replace any existing ones)')
+
+
+	@transaction.atomic
+	def handle(self, *args, **options):
+		try:
+			user = User.objects.get(username=options['username'])
+		except User.DoesNotExist:
+			raise CommandError(_('User with username "%s" does not exist') % options['username'])
+
+		if not options['keep_existing']:
+			Token.objects.filter(user=user).delete() # If any
+
+		token = Token(user=user)
+		token.save()
+
+		self.stdout.write(_("Generated token for user %(user)s: %(token)s.") % {'user': user, 'token': token.token})
+		self.stdout.write(_("User now has %(count)d token(s).") % {'count': Token.objects.filter(user=user).count()} )

--- a/binder/plugins/token_auth/management/commands/delete_user_token.py
+++ b/binder/plugins/token_auth/management/commands/delete_user_token.py
@@ -1,0 +1,24 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.utils.translation import ugettext as _
+from django.contrib.auth.models import User
+from django.db import transaction
+
+from binder.plugins.token_auth.models import Token
+
+class Command(BaseCommand):
+	help = _('Delete all tokens for the given user')
+
+	def add_arguments(self, parser):
+		parser.add_argument('username', type=str)
+
+
+	@transaction.atomic
+	def handle(self, *args, **options):
+		try:
+			user = User.objects.get(username=options['username'])
+		except User.DoesNotExist:
+			raise CommandError(_('User with username "%s" does not exist') % options['username'])
+
+		counts = Token.objects.filter(user=user).delete()
+
+		self.stdout.write(_("Deleted %(count)d token(s) for user %(user)s.") % {'count': counts[0], 'user': user} )

--- a/binder/plugins/token_auth/models.py
+++ b/binder/plugins/token_auth/models.py
@@ -30,7 +30,7 @@ class Token(BinderModel):
 
 	@property
 	def expires_at(self):
-		expire_time = settings.BINDER_TOKEN_EXPIRE_TIME
+		expire_time = getattr(settings, 'BINDER_TOKEN_EXPIRE_TIME', None)
 
 		if expire_time is None:
 			return None

--- a/binder/plugins/views/multi_request.py
+++ b/binder/plugins/views/multi_request.py
@@ -33,8 +33,8 @@ def multi_request_view(request):
 	responses = []
 	key_responses = {}
 
-	if not isinstance(requests, list) or not requests:
-		raise BinderRequestError('requests should be a non empty list')
+	if not isinstance(requests, list):
+		raise BinderRequestError('requests should be a list')
 
 	handler = RequestHandler()
 

--- a/binder/plugins/views/multi_request.py
+++ b/binder/plugins/views/multi_request.py
@@ -43,6 +43,7 @@ def multi_request_view(request):
 			for i, data in enumerate(requests):
 				key = data.pop('key', i)
 
+				# Get response from request
 				try:
 					req = parse_request(
 						data, allowed_methods, key_responses, request,
@@ -52,14 +53,15 @@ def multi_request_view(request):
 				else:
 					res = handler.get_response(req)
 
+				# Serialize and add to responses
 				res_data = serialize_response(res)
 				responses.append(res_data)
 
-				res_data['key'] = key
+				# Add by key so that we can reference it in other requests
 				key_responses[key] = res_data
 
+				# Rollback the transaction if the request has a failing code
 				if res.status_code >= 400:
-					# rollback the transaction
 					raise ErrorStatus(res.status_code)
 	except ErrorStatus as e:
 		status = e.status

--- a/binder/plugins/views/multi_request.py
+++ b/binder/plugins/views/multi_request.py
@@ -27,14 +27,22 @@ def multi_request_view(request):
 	elif request.method == 'POST':
 		allowed_methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']
 	else:
-		raise BinderMethodNotAllowed()
+		try:
+			raise BinderMethodNotAllowed()
+		except BinderException as e:
+			e.log()
+			return e.response(request)
 
 	requests = jsonloads(request.body)
 	responses = []
 	key_responses = {}
 
 	if not isinstance(requests, list):
-		raise BinderRequestError('requests should be a list')
+		try:
+			raise BinderRequestError('requests should be a list')
+		except BinderException as e:
+			e.log()
+			return e.response(request)
 
 	handler = RequestHandler()
 
@@ -49,6 +57,7 @@ def multi_request_view(request):
 						data, allowed_methods, key_responses, request,
 					)
 				except BinderException as e:
+					e.log()
 					res = e.response(request)
 				else:
 					res = handler.get_response(req)

--- a/binder/plugins/views/multi_request.py
+++ b/binder/plugins/views/multi_request.py
@@ -1,0 +1,198 @@
+from django.http import HttpRequest, JsonResponse
+from django.db import transaction
+from django.core.handlers.base import BaseHandler
+
+from binder.exceptions import (
+	BinderException, BinderRequestError, BinderMethodNotAllowed,
+)
+from binder.json import jsonloads, jsondumps
+
+
+class RequestHandler(BaseHandler):
+
+	def __init__(self):
+		self.load_middleware()
+
+
+class ErrorStatus(Exception):
+
+	def __init__(self, status):
+		super().__init__()
+		self.status = status
+
+
+def multi_request_view(request):
+	if request.method == 'GET':
+		allowed_methods = ['GET']
+	elif request.method == 'POST':
+		allowed_methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']
+	else:
+		raise BinderMethodNotAllowed()
+
+	requests = jsonloads(request.body)
+	responses = []
+	key_responses = {}
+
+	if not isinstance(requests, list) or not requests:
+		raise BinderRequestError('requests should be a non empty list')
+
+	handler = RequestHandler()
+
+	try:
+		with transaction.atomic():
+			for i, data in enumerate(requests):
+				key = data.pop('key', i)
+
+				try:
+					req = parse_request(
+						data, allowed_methods, key_responses, request,
+					)
+				except BinderException as e:
+					res = e.response(request)
+				else:
+					res = handler.get_response(req)
+
+				res_data = serialize_response(res)
+				responses.append(res_data)
+
+				res_data['key'] = key
+				key_responses[key] = res_data
+
+				if res.status_code >= 400:
+					# rollback the transaction
+					raise ErrorStatus(res.status_code)
+	except ErrorStatus as e:
+		status = e.status
+	else:
+		status = 200
+
+	return JsonResponse(responses, safe=False, status=status)
+
+
+def parse_request(data, allowed_methods, responses, request):
+	if not isinstance(data, dict):
+		raise BinderRequestError('requests should be dicts')
+
+	# Transform data
+	transforms = data.pop('transforms', [])
+	path_params = {}
+
+	if not isinstance(transforms, list):
+		raise BinderRequestError('transforms should be a list')
+
+	for transform in transforms:
+		if 'source' not in transform:
+			raise BinderRequestError('transforms require the field source')
+		if 'target' not in transform:
+			raise BinderRequestError('transforms require the field target')
+		if (
+			not isinstance(transform['source'], list) or
+			len(transform['source']) < 1
+		):
+			raise BinderRequestError('source must be a non empty list')
+		if (
+			not isinstance(transform['target'], list) or
+			len(transform['target']) < 2
+		):
+			raise BinderRequestError('target must be a non empty list')
+
+		# Get value through source
+		value = responses
+		for key in transform['source']:
+			if not isinstance(value, (list, dict)):
+				raise BinderRequestError(
+					'source can only iterate through lists and dicts'
+				)
+			try:
+				value = value[key]
+			except (KeyError, IndexError):
+				raise BinderRequestError(
+					'invalid source {}, error at key {}'
+					.format(transform['source'], key)
+				)
+
+		# Set value according to target
+		if transform['target'][0] == 'path':
+			# Special case path to allow for formatting
+			if len(transform['target']) == 1:
+				data['path'] = value
+			elif len(transform['target']) == 2:
+				path_params[transform['target'][1]] = value
+			else:
+				raise BinderRequestError('path target must have length 1 or 2')
+		else:
+			target = data
+			target_key = transform['target'][0]
+			for key in transform['target'][1:]:
+				if not isinstance(target, (list, dict)):
+					raise BinderRequestError(
+						'target can only iterate through lists and dicts'
+					)
+				try:
+					target = target[target_key]
+				except (KeyError, IndexError):
+					raise BinderRequestError(
+						'invalid target {}, error at key {}'
+						.format(transform['target'], target_key)
+					)
+				target_key = key
+			if not isinstance(target, (list, dict)):
+				raise BinderRequestError(
+					'target can only iterate through lists and dicts'
+				)
+			try:
+				target[target_key] = value
+			except IndexError:
+				raise BinderRequestError(
+					'invalid target {}, error at key {}'
+					.format(transform['target'], target_key)
+				)
+
+	if 'path' in data:
+		try:
+			data['path'] = data['path'].format(**path_params)
+		except KeyError as e:
+			raise BinderRequestError(
+				'missing key for path: {}'.format(e.args[0])
+			)
+
+	# Validate request
+	if 'method' not in data:
+		raise BinderRequestError('requests require the field method')
+	if 'path' not in data:
+		raise BinderRequestError('requests require the field path')
+
+	# Validate method is allowed
+	if data['method'] not in allowed_methods:
+		print('METHODS', data['method'], allowed_methods)
+		raise BinderMethodNotAllowed()
+
+	# Create request
+	req = HttpRequest()
+	req.method = data['method']
+	req.path = data['path']
+	req.path_info = req.path
+	req.COOKIES = request.COOKIES
+	req.META = request.META
+	req.content_type = 'application/json'
+
+	if 'body' in data:
+		req._body = jsondumps(data['body']).encode()
+	else:
+		req._body = b''
+
+	return req
+
+
+def serialize_response(response):
+	content_type = response.get('Content-Type', '')
+	if content_type == 'application/json':
+		body = jsonloads(response.content)
+	else:
+		body = response.content.decode()
+
+	return {
+		'status': response.status_code,
+		'body': body,
+		'content_type': content_type,
+	}

--- a/binder/tests/plugins/test_multi_request.py
+++ b/binder/tests/plugins/test_multi_request.py
@@ -1,0 +1,88 @@
+from django.test import TestCase, Client
+from django.contrib.auth.models import User
+
+from binder.json import jsonloads, jsondumps
+
+from ..testapp.models import Animal
+
+
+class MultiRequestTest(TestCase):
+	def setUp(self):
+		super().setUp()
+		u = User(username='testuser', is_active=True, is_superuser=True)
+		u.set_password('test')
+		u.save()
+		self.client = Client()
+		r = self.client.login(username='testuser', password='test')
+		self.assertTrue(r)
+
+	def test_create_and_update(self):
+		requests = [
+			{
+				'method': 'POST',
+				'path': '/zoo/',
+				'body': {
+					'name': 'Zoo',
+				},
+			},
+			{
+				'method': 'POST',
+				'path': '/animal/',
+				'body': {
+					'name': 'Foo',
+				},
+				'transforms': [{
+					'source': [0, 'body', 'id'],
+					'target': ['body', 'zoo'],
+				}],
+			},
+			{
+				'method': 'PUT',
+				'path': '/animal/{id}/',
+				'body': {
+					'name': 'Bar',
+				},
+				'transforms': [{
+					'source': [1, 'body', 'id'],
+					'target': ['path', 'id'],
+				}],
+			},
+		]
+
+		response = self.client.post(
+			'/multi/',
+			data=jsondumps(requests),
+			content_type='application/json',
+		)
+		self.assertEqual(response.status_code, 200)
+
+	def test_transaction(self):
+		requests = [
+			# This request should work fine
+			{
+				'method': 'POST',
+				'path': '/animal/',
+				'body': {
+					'name': 'Foo',
+				},
+			},
+			# This one should error
+			{
+				'method': 'POST',
+				'path': '/animal/',
+				'body': {
+					'NONEXISTINGFIELD': 'Bar',
+				},
+			},
+		]
+
+		response = self.client.post(
+			'/multi/',
+			data=jsondumps(requests),
+			content_type='application/json',
+		)
+		self.assertEqual(response.status_code, 418)
+		response = jsonloads(response.content)
+
+		with self.assertRaises(Animal.DoesNotExist):
+			Animal.objects.get(pk=response[0]['body']['id'])

--- a/binder/tests/plugins/test_multi_request.py
+++ b/binder/tests/plugins/test_multi_request.py
@@ -86,3 +86,10 @@ class MultiRequestTest(TestCase):
 
 		with self.assertRaises(Animal.DoesNotExist):
 			Animal.objects.get(pk=response[0]['body']['id'])
+
+	def test_invalid_method(self):
+		response = self.client.put(
+			'/multi/', data=b'[]',
+			content_type='application/json',
+		)
+		self.assertEqual(response.status_code, 405)

--- a/binder/tests/plugins/test_token_auth.py
+++ b/binder/tests/plugins/test_token_auth.py
@@ -1,7 +1,10 @@
+from io import StringIO
 from datetime import timedelta
 
 from django.test import TestCase, Client, override_settings
 from django.contrib.auth.models import User
+from django.core.management import call_command
+from django.core.management.base import CommandError
 
 from binder.plugins.token_auth.models import Token
 from binder.json import jsonloads
@@ -118,3 +121,138 @@ class TokenLoginTest(TestCase):
 		self.assertEqual(res.status_code, 403)
 		res = jsonloads(res.content)
 		self.assertEqual(res['code'], 'NotAuthenticated')
+
+
+
+class CreateUserTokenTest(TestCase):
+	def test_create_user_token_fails_cleanly_when_user_does_not_exist(self):
+		with self.assertRaises(CommandError) as cm:
+			call_command('create_user_token', 'testuser@example.com')
+
+		self.assertEqual('User with username "testuser@example.com" does not exist', str(cm.exception))
+		self.assertFalse(Token.objects.exists())
+
+
+	def test_create_user_token_creates_token_when_user_exists(self):
+		user = User(username='testuser@example.com')
+		user.save()
+
+		out = StringIO()
+		call_command('create_user_token', 'testuser@example.com', stdout=out)
+
+		self.assertEqual(1, Token.objects.count())
+		self.assertEqual(1, Token.objects.filter(user=user).count())
+
+		self.assertIn("Generated token for user testuser@example.com: %s." % Token.objects.get().token, out.getvalue())
+		self.assertIn("User now has 1 token(s).", out.getvalue())
+
+
+	def test_create_user_token_replaces_existing_tokens_for_passed_user_when_keep_is_omitted(self):
+		user1 = User(username='someone@example.com') # Ensure we don't destroy other users tokens
+		user1.save()
+		token1 = Token(user=user1)
+		token1.save()
+
+		user2 = User(username='testuser@example.com')
+		user2.save()
+		token2 = Token(user=user2)
+		token2.save()
+		token3 = Token(user=user2)
+		token3.save()
+
+		self.assertEqual(3, Token.objects.count())
+
+		out = StringIO()
+		call_command('create_user_token', 'testuser@example.com', stdout=out)
+
+		self.assertEqual(2, Token.objects.count())
+		self.assertEqual(1, Token.objects.filter(user=user2).count())
+
+		self.assertTrue(Token.objects.filter(id=token1.id).exists())
+		self.assertFalse(Token.objects.filter(id=token2.id).exists())
+		self.assertFalse(Token.objects.filter(id=token3.id).exists())
+
+		token4 = Token.objects.exclude(id__in=[token1.id, token2.id, token3.id]).get()
+		self.assertNotEqual(token1.token, token4.token)
+		self.assertNotEqual(token2.token, token4.token)
+		self.assertNotEqual(token3.token, token4.token)
+
+		self.assertIn("Generated token for user testuser@example.com: %s." % Token.objects.filter(user=user2).exclude(id__in=[token2.id, token3.id]).get().token, out.getvalue())
+		self.assertIn("User now has 1 token(s).", out.getvalue())
+
+
+	def test_create_user_token_keeps_existing_tokens_when_keep_is_passed(self):
+		user = User(username='testuser@example.com')
+		user.save()
+		token1 = Token(user=user)
+		token1.save()
+		token2 = Token(user=user)
+		token2.save()
+
+		self.assertEqual(2, Token.objects.count())
+
+		out = StringIO()
+		call_command('create_user_token', '-k', 'testuser@example.com', stdout=out)
+
+		self.assertEqual(3, Token.objects.count())
+		self.assertEqual(3, Token.objects.filter(user=user).count())
+
+		self.assertTrue(Token.objects.filter(id=token1.id).exists())
+		self.assertTrue(Token.objects.filter(id=token2.id).exists())
+
+		token3 = Token.objects.exclude(id__in=[token1.id, token2.id]).get()
+
+		self.assertIn("Generated token for user testuser@example.com: %s." % Token.objects.filter(user=user).exclude(id__in=[token1.id, token2.id]).get().token, out.getvalue())
+		self.assertIn("User now has 3 token(s).", out.getvalue())
+
+		out = StringIO()
+		call_command('create_user_token', '--keep-existing', 'testuser@example.com', stdout=out)
+
+		self.assertEqual(4, Token.objects.count())
+		self.assertEqual(4, Token.objects.filter(user=user).count())
+
+		token4 = Token.objects.exclude(id__in=[token1.id, token2.id, token3.id]).get()
+
+		self.assertNotEqual(token1.token, token4.token)
+		self.assertNotEqual(token2.token, token4.token)
+		self.assertNotEqual(token3.token, token4.token)
+
+		self.assertIn("Generated token for user testuser@example.com: %s." % Token.objects.filter(user=user).exclude(id__in=[token1.id, token2.id, token3.id]).get().token, out.getvalue())
+		self.assertIn("User now has 4 token(s).", out.getvalue())
+
+
+class DeleteUserTokenTest(TestCase):
+	def test_delete_user_token_fails_cleanly_when_user_does_not_exist(self):
+		with self.assertRaises(CommandError) as cm:
+			call_command('delete_user_token', 'testuser@example.com')
+
+		self.assertEqual('User with username "testuser@example.com" does not exist', str(cm.exception))
+		self.assertFalse(Token.objects.exists())
+
+
+	def test_delete_user_token_deletes_existing_tokens_but_only_for_passed_user(self):
+		user1 = User(username='someone@example.com') # Ensure we don't destroy other users tokens
+		user1.save()
+		token1 = Token(user=user1)
+		token1.save()
+
+		user2 = User(username='testuser@example.com')
+		user2.save()
+		token2 = Token(user=user2)
+		token2.save()
+		token3 = Token(user=user2)
+		token3.save()
+
+		self.assertEqual(3, Token.objects.count())
+
+		out = StringIO()
+		call_command('delete_user_token', 'testuser@example.com', stdout=out)
+
+		self.assertEqual(1, Token.objects.count())
+		self.assertEqual(0, Token.objects.filter(user=user2).count())
+
+		self.assertTrue(Token.objects.filter(id=token1.id).exists())
+		self.assertFalse(Token.objects.filter(id=token2.id).exists())
+		self.assertFalse(Token.objects.filter(id=token3.id).exists())
+
+		self.assertIn("Deleted 2 token(s) for user testuser@example.com.", out.getvalue())

--- a/binder/tests/test_inheritance.py
+++ b/binder/tests/test_inheritance.py
@@ -47,8 +47,6 @@ class InheritanceTest(TestCase):
 				},
 			}),
 		)
-		if (response.status_code != 200):
-			print(response.content)
 		self.assertEqual(response.status_code, 200)
 
 		zoo.refresh_from_db()
@@ -61,4 +59,59 @@ class InheritanceTest(TestCase):
 		self.assertEqual(mane_magnificence_map, {
 			'Mufasa': 10,
 			'Scar': 4,
+		})
+
+	def test_create_lion_with_animal(self):
+		response = self.client.put(
+			'/animal/',
+			content_type='application/json',
+			data=json.dumps({
+				'data': [{
+					'id': -1,
+					'name': 'OVERRIDE THIS SHIET',
+				}],
+				'with': {'lion': [{
+					'id': -1,
+					'name': 'Mufasa',
+					'mane_magnificence': 10,
+				}]},
+			}),
+		)
+
+		self.assertEqual(response.status_code, 200)
+		res_data = json.loads(response.content.decode())
+		lion_id = res_data['idmap']['lion'][0][1]
+		self.assertEqual(res_data, {
+			'idmap': {
+				'animal': [[-1, lion_id]],
+				'lion': [[-1, lion_id]],
+			},
+		})
+
+	def test_create_lion_with_animal_with_ref(self):
+		response = self.client.put(
+			'/animal/',
+			content_type='application/json',
+			data=json.dumps({
+				'data': [{
+					'id': -1,
+					'name': 'OVERRIDE THIS SHIET',
+					'lion': -1,
+				}],
+				'with': {'lion': [{
+					'id': -1,
+					'name': 'Mufasa',
+					'mane_magnificence': 10,
+				}]},
+			}),
+		)
+
+		self.assertEqual(response.status_code, 200)
+		res_data = json.loads(response.content.decode())
+		lion_id = res_data['idmap']['lion'][0][1]
+		self.assertEqual(res_data, {
+			'idmap': {
+				'animal': [[-1, lion_id]],
+				'lion': [[-1, lion_id]],
+			},
 		})

--- a/binder/tests/test_inheritance.py
+++ b/binder/tests/test_inheritance.py
@@ -69,9 +69,10 @@ class InheritanceTest(TestCase):
 				'data': [{
 					'id': -1,
 					'name': 'OVERRIDE THIS SHIET',
+					'lion': -2,
 				}],
 				'with': {'lion': [{
-					'id': -1,
+					'id': -2,
 					'name': 'Mufasa',
 					'mane_magnificence': 10,
 				}]},
@@ -84,11 +85,11 @@ class InheritanceTest(TestCase):
 		self.assertEqual(res_data, {
 			'idmap': {
 				'animal': [[-1, lion_id]],
-				'lion': [[-1, lion_id]],
+				'lion': [[-2, lion_id]],
 			},
 		})
 
-	def test_create_lion_with_animal_with_ref(self):
+	def test_create_lion_with_animal_and_zoo(self):
 		response = self.client.put(
 			'/animal/',
 			content_type='application/json',
@@ -96,22 +97,28 @@ class InheritanceTest(TestCase):
 				'data': [{
 					'id': -1,
 					'name': 'OVERRIDE THIS SHIET',
-					'lion': -1,
+					'lion': -2,
 				}],
-				'with': {'lion': [{
-					'id': -1,
-					'name': 'Mufasa',
-					'mane_magnificence': 10,
-				}]},
+				'with': {
+					'lion': [{
+						'id': -2,
+						'name': 'Mufasa',
+						'mane_magnificence': 10,
+					}],
+					'zoo': [{
+						'id': -3,
+						'name': 'Artis',
+						'animals': [-1],
+					}],
+				},
 			}),
 		)
 
 		self.assertEqual(response.status_code, 200)
 		res_data = json.loads(response.content.decode())
-		lion_id = res_data['idmap']['lion'][0][1]
-		self.assertEqual(res_data, {
-			'idmap': {
-				'animal': [[-1, lion_id]],
-				'lion': [[-1, lion_id]],
-			},
-		})
+		zoo_id = res_data['idmap']['zoo'][0][1]
+		animal_id = res_data['idmap']['animal'][0][1]
+
+		zoo = Zoo.objects.get(pk=zoo_id)
+		zoo_animal_ids = [animal.id for animal in zoo.animals.all()]
+		self.assertEqual(zoo_animal_ids, [animal_id])

--- a/binder/tests/test_pagination.py
+++ b/binder/tests/test_pagination.py
@@ -1,0 +1,349 @@
+from django.test import TestCase, Client
+from django.contrib.auth.models import User
+
+from binder.json import jsonloads
+from .testapp.models import Animal, ContactPerson, Zoo, Caretaker
+from .testapp.views import AnimalView
+
+class CustomDefaultLimit:
+	def __init__(self, cls, limit):
+		self.cls = cls
+		self.new_limit = limit
+
+	def __enter__(self):
+		self.old_limit = self.cls.limit_default
+		self.cls.limit_default = self.new_limit
+
+	def __exit__(self, *args, **kwargs):
+		self.cls.limit_default = self.old_limit
+
+
+class CustomMaxLimit:
+	def __init__(self, cls, limit):
+		self.cls = cls
+		self.new_limit = limit
+
+	def __enter__(self):
+		self.old_limit = self.cls.limit_max
+		self.cls.limit_max = self.new_limit
+
+	def __exit__(self, *args, **kwargs):
+		self.cls.limit_max = self.old_limit
+
+
+class TestPagination(TestCase):
+	def setUp(self):
+		super().setUp()
+		u = User(username='testuser', is_active=True, is_superuser=True)
+		u.set_password('test')
+		u.save()
+		self.client = Client()
+		r = self.client.login(username='testuser', password='test')
+		self.assertTrue(r)
+
+		self.gaia = Zoo(name='GaiaZOO') # 3
+		self.gaia.save()
+
+		self.wildlands = Zoo(name='Wildlands Adventure Zoo Emmen') # 4
+		self.wildlands.full_clean()
+		self.wildlands.save()
+
+		self.artis = Zoo(name='Artis') # 1
+		self.artis.full_clean()
+		self.artis.save()
+
+		self.harderwijk = Zoo(name='Dolfinarium Harderwijk') # 2
+		self.harderwijk.full_clean()
+		self.harderwijk.save()
+
+		self.donald = Animal(name='Donald Duck', zoo=self.wildlands) # 1
+		self.donald.save()
+		self.mickey = Animal(name='Mickey Mouse', zoo=self.gaia) # 2
+		self.mickey.save()
+		self.pluto = Animal(name='Pluto', zoo=self.artis) # 4
+		self.pluto.save()
+		self.minnie = Animal(name='Minnie Mouse', zoo=self.gaia) # 3
+		self.minnie.save()
+		self.scrooge = Animal(name='Scrooge McDuck', zoo=self.artis) # 5
+		self.scrooge.save()
+
+		self.director = ContactPerson(name='Director') # 2
+		self.director.save()
+
+		self.gaia.contacts.add(self.director)
+		self.wildlands.contacts.add(self.director)
+
+		self.janitor = ContactPerson(name='Janitor') # 3
+		self.janitor.save()
+
+		self.gaia.contacts.add(self.janitor)
+
+		self.cleaning_lady = ContactPerson(name='Cleaning lady') # 1
+		self.cleaning_lady.save()
+
+		self.gaia.contacts.add(self.cleaning_lady)
+
+		self.caretaker1 = Caretaker(name='Caretaker 1') # 1 (Ran out of inspiration)
+		self.caretaker1.save()
+
+		self.caretaker2 = Caretaker(name='Caretaker 2') # 2
+		self.caretaker2.save()
+
+		self.caretaker1.animals.add(self.donald)
+		self.caretaker1.animals.add(self.mickey)
+		self.caretaker1.animals.add(self.scrooge)
+
+		self.caretaker2.animals.add(self.pluto)
+		self.caretaker2.animals.add(self.minnie)
+
+
+	def test_limit_parsing(self):
+		response = self.client.get('/animal/', data={'order_by': 'name', 'limit': 'haha'})
+		self.assertEqual(response.status_code, 418)
+
+		response = self.client.get('/animal/', data={'order_by': 'name', 'limit': '-1'})
+		self.assertEqual(response.status_code, 418)
+
+		response = self.client.get('/animal/', data={'order_by': 'name', 'limit': '0'})
+		self.assertEqual(response.status_code, 200)
+
+		response = self.client.get('/animal/', data={'order_by': 'name', 'limit': 'none'})
+		self.assertEqual(response.status_code, 200)
+
+		response = self.client.get('/animal/', data={'order_by': 'name', 'limit': 'nope'})
+		self.assertEqual(response.status_code, 418)
+
+		response = self.client.get('/animal/', data={'order_by': 'name', 'limit': ''})
+		self.assertEqual(response.status_code, 418)
+
+
+	def test_basic_limit_offset(self):
+		response = self.client.get('/animal/', data={'order_by': 'name'})
+		self.assertEqual(response.status_code, 200)
+		data = jsonloads(response.content)
+
+		self.assertEqual(5, data['meta']['total_records'])
+		self.assertEqual(5, len(data['data']))
+
+		response = self.client.get('/animal/', data={'limit': 1, 'order_by': 'name'})
+		self.assertEqual(response.status_code, 200)
+		data = jsonloads(response.content)
+
+		self.assertEqual(5, data['meta']['total_records'])
+		self.assertEqual(1, len(data['data']))
+		self.assertEqual(self.donald.id, data['data'][0]['id'])
+
+
+		response = self.client.get('/animal/', data={'limit': 1, 'offset': 1, 'order_by': 'name'})
+		self.assertEqual(response.status_code, 200)
+		data = jsonloads(response.content)
+
+		self.assertEqual(5, data['meta']['total_records'])
+		self.assertEqual(1, len(data['data']))
+		self.assertEqual(self.mickey.id, data['data'][0]['id'])
+
+
+		response = self.client.get('/animal/', data={'limit': 2, 'offset': 1, 'order_by': 'name'})
+		self.assertEqual(response.status_code, 200)
+		data = jsonloads(response.content)
+
+		self.assertEqual(5, data['meta']['total_records'])
+		self.assertEqual(2, len(data['data']))
+		self.assertEqual(self.mickey.id, data['data'][0]['id'])
+		self.assertEqual(self.minnie.id, data['data'][1]['id'])
+
+
+		response = self.client.get('/animal/', data={'limit': 2, 'offset': 100, 'order_by': 'name'})
+		self.assertEqual(response.status_code, 200)
+		data = jsonloads(response.content)
+
+		self.assertEqual(5, data['meta']['total_records'])
+		self.assertEqual(0, len(data['data']))
+
+
+	def test_basic_limit_offset_honors_custom_default(self):
+		with CustomDefaultLimit(AnimalView, 2):
+			response = self.client.get('/animal/', data={'order_by': 'name'})
+			self.assertEqual(response.status_code, 200)
+			data = jsonloads(response.content)
+
+			self.assertEqual(5, data['meta']['total_records'])
+			self.assertEqual(2, len(data['data']))
+			self.assertEqual(self.donald.id, data['data'][0]['id'])
+			self.assertEqual(self.mickey.id, data['data'][1]['id'])
+
+
+			response = self.client.get('/animal/', data={'order_by': 'name', 'limit': 'none'})
+			self.assertEqual(response.status_code, 200)
+			data = jsonloads(response.content)
+
+			self.assertEqual(5, data['meta']['total_records'])
+			self.assertEqual(5, len(data['data']))
+
+
+	def test_basic_limit_offset_honors_custom_maximum(self):
+		with CustomMaxLimit(AnimalView, 3):
+			# This is inconsistent with the default value, and Binder fails
+			response = self.client.get('/animal/', data={'order_by': 'name'})
+			self.assertEqual(response.status_code, 418)
+			data = jsonloads(response.content)
+
+			response = self.client.get('/animal/', data={'order_by': 'name', 'limit': 2})
+			self.assertEqual(response.status_code, 200)
+			data = jsonloads(response.content)
+
+			self.assertEqual(5, data['meta']['total_records'])
+			self.assertEqual(2, len(data['data']))
+			self.assertEqual(self.donald.id, data['data'][0]['id'])
+			self.assertEqual(self.mickey.id, data['data'][1]['id'])
+
+
+			with CustomDefaultLimit(AnimalView, 2):
+				response = self.client.get('/animal/', data={'order_by': 'name'})
+				self.assertEqual(response.status_code, 200)
+				data = jsonloads(response.content)
+
+				self.assertEqual(5, data['meta']['total_records'])
+				self.assertEqual(2, len(data['data']))
+				self.assertEqual(self.donald.id, data['data'][0]['id'])
+				self.assertEqual(self.mickey.id, data['data'][1]['id'])
+
+
+				response = self.client.get('/animal/', data={'order_by': 'name', 'offset': 3})
+				self.assertEqual(response.status_code, 200)
+				data = jsonloads(response.content)
+
+				self.assertEqual(5, data['meta']['total_records'])
+				self.assertEqual(2, len(data['data']))
+				self.assertEqual(self.pluto.id, data['data'][0]['id'])
+				self.assertEqual(self.scrooge.id, data['data'][1]['id'])
+
+				response = self.client.get('/animal/', data={'order_by': 'name', 'limit': 'none'})
+				self.assertEqual(response.status_code, 418)
+
+				response = self.client.get('/animal/', data={'order_by': 'name', 'limit': 4})
+				self.assertEqual(response.status_code, 418)
+
+
+				response = self.client.get('/animal/', data={'order_by': 'name', 'limit': 3})
+				self.assertEqual(response.status_code, 200)
+
+
+	def test_limit_offset_using_with(self):
+		response = self.client.get('/zoo/', data={'order_by': 'name', 'limit': 2, 'with': 'animals'})
+		self.assertEqual(response.status_code, 200)
+		data = jsonloads(response.content)
+
+		self.assertEqual(4, data['meta']['total_records'])
+		self.assertEqual(2, len(data['data']))
+		self.assertEqual(self.artis.id, data['data'][0]['id'])
+		self.assertEqual(self.harderwijk.id, data['data'][1]['id'])
+
+		self.assertEqual('animal', data['with_mapping']['animals'])
+		self.assertEqual('zoo', data['with_related_name_mapping']['animals'])
+
+		self.assertEqual({self.pluto.id, self.scrooge.id}, set(data['data'][0]['animals']))
+		self.assertEqual([], data['data'][1]['animals'])
+
+
+		response = self.client.get('/zoo/', data={'order_by': 'name', 'limit': 2, 'offset': 1, 'with': 'animals'})
+		self.assertEqual(response.status_code, 200)
+		data = jsonloads(response.content)
+
+		self.assertEqual(4, data['meta']['total_records'])
+		self.assertEqual(2, len(data['data']))
+		self.assertEqual(self.harderwijk.id, data['data'][0]['id'])
+		self.assertEqual(self.gaia.id, data['data'][1]['id'])
+
+		self.assertEqual('animal', data['with_mapping']['animals'])
+		self.assertEqual('zoo', data['with_related_name_mapping']['animals'])
+
+		self.assertEqual([], data['data'][0]['animals'])
+		self.assertEqual({self.mickey.id, self.minnie.id}, set(data['data'][1]['animals']))
+
+
+	def test_limit_offset_filtering(self):
+		response = self.client.get('/zoo/', data={'order_by': 'name', 'limit': 2, '.name:not': 'GaiaZOO'})
+		self.assertEqual(response.status_code, 200)
+		data = jsonloads(response.content)
+
+		self.assertEqual(3, data['meta']['total_records'])
+		self.assertEqual(2, len(data['data']))
+		self.assertEqual(self.artis.id, data['data'][0]['id'])
+		self.assertEqual(self.harderwijk.id, data['data'][1]['id'])
+
+		response = self.client.get('/zoo/', data={'order_by': 'name', 'limit': 2, 'offset': 1, '.name:not': 'GaiaZOO'})
+		self.assertEqual(response.status_code, 200)
+		data = jsonloads(response.content)
+
+		self.assertEqual(3, data['meta']['total_records'])
+		self.assertEqual(2, len(data['data']))
+		self.assertEqual(self.harderwijk.id, data['data'][0]['id'])
+		self.assertEqual(self.wildlands.id, data['data'][1]['id'])
+
+
+	def test_limit_offset_related_filtering(self):
+		response = self.client.get('/contact_person/', data={'order_by': 'name', 'limit': 2, '.zoos.name': 'Wildlands Adventure Zoo Emmen'})
+		self.assertEqual(response.status_code, 200)
+		data = jsonloads(response.content)
+
+		self.assertEqual(1, data['meta']['total_records'])
+		self.assertEqual(1, len(data['data']))
+		self.assertEqual(self.director.id, data['data'][0]['id'])
+
+
+		response = self.client.get('/contact_person/', data={'order_by': 'name', 'limit': 2, 'offset': 1, '.zoos.name': 'Wildlands Adventure Zoo Emmen'})
+		self.assertEqual(response.status_code, 200)
+		data = jsonloads(response.content)
+
+		self.assertEqual(1, data['meta']['total_records'])
+		self.assertEqual(0, len(data['data']))
+
+
+		response = self.client.get('/contact_person/', data={'order_by': 'name', 'limit': 2, 'offset': 1, '.zoos.name': 'GaiaZOO'})
+		self.assertEqual(response.status_code, 200)
+		data = jsonloads(response.content)
+
+		self.assertEqual(3, data['meta']['total_records'])
+		self.assertEqual(2, len(data['data']))
+		self.assertEqual(self.director.id, data['data'][0]['id'])
+		self.assertEqual(self.janitor.id, data['data'][1]['id'])
+
+
+		# Same set, but deeper filtering
+		response = self.client.get('/contact_person/', data={'order_by': 'name', 'limit': 2, 'offset': 1, '.zoos.animals.name': 'Mickey Mouse'})
+		self.assertEqual(response.status_code, 200)
+		data = jsonloads(response.content)
+
+		self.assertEqual(3, data['meta']['total_records'])
+		self.assertEqual(2, len(data['data']))
+		self.assertEqual(self.director.id, data['data'][0]['id'])
+		self.assertEqual(self.janitor.id, data['data'][1]['id'])
+
+
+	def test_limit_offset_filtering_on_annotations(self):
+		response = self.client.get('/caretaker/', data={'order_by': 'name', 'limit': 1, 'offset': 0, '.animal_count:gt': 1})
+		self.assertEqual(response.status_code, 200)
+		data = jsonloads(response.content)
+
+		self.assertEqual(2, data['meta']['total_records'])
+		self.assertEqual(1, len(data['data']))
+		self.assertEqual(self.caretaker1.id, data['data'][0]['id'])
+
+
+		response = self.client.get('/caretaker/', data={'order_by': 'name', 'limit': 1, 'offset': 1, '.animal_count:gt': 1})
+		self.assertEqual(response.status_code, 200)
+		data = jsonloads(response.content)
+
+		self.assertEqual(2, data['meta']['total_records'])
+		self.assertEqual(1, len(data['data']))
+		self.assertEqual(self.caretaker2.id, data['data'][0]['id'])
+
+
+		response = self.client.get('/caretaker/', data={'order_by': 'name', 'limit': 1, 'offset': 0, '.animal_count:gt': 2})
+		self.assertEqual(response.status_code, 200)
+		data = jsonloads(response.content)
+
+		self.assertEqual(1, data['meta']['total_records'])
+		self.assertEqual(1, len(data['data']))
+		self.assertEqual(self.caretaker1.id, data['data'][0]['id'])

--- a/binder/tests/testapp/urls.py
+++ b/binder/tests/testapp/urls.py
@@ -6,6 +6,7 @@ import binder.views # noqa
 import binder.history # noqa
 import binder.models # noqa
 import binder.plugins.token_auth.views # noqa
+from binder.plugins.views.multi_request import multi_request_view
 from .views import animal, caretaker, costume, custom, zoo, contact_person, gate # noqa
 
 router = binder.router.Router().register(binder.views.ModelView)
@@ -14,6 +15,7 @@ room_controller = binder.websocket.RoomController().register(binder.views.ModelV
 urlpatterns = [
 	url(r'^custom/route', custom.custom, name='custom'),
 	url(r'^user/$', custom.user, name='user'),
+	url(r'^multi/$', multi_request_view, name='multi_request'),
 	url(r'^', include(router.urls)),
 	url(r'^', binder.views.api_catchall, name='catchall'),
 ]

--- a/binder/tests_discoverer.py
+++ b/binder/tests_discoverer.py
@@ -1,0 +1,21 @@
+from django.test.runner import is_discoverable
+from django.apps import apps
+
+# This prevents discoverer from loading models and views, which will
+# cause all sorts of random failures.
+def load_tests(loader, tests, pattern):
+    print("DISCOVER TESTS")
+    for app in apps.get_app_configs():
+        app_path = app.path
+        test_dir = '{}/tests/'.format(app_path)
+        try:
+            if is_discoverable(test_dir):
+                tests.addTests(loader.discover(test_dir))
+                print("Discover tests for app ", app.verbose_name)
+        except AssertionError:
+            # This is thrown if the app is loaded from the venv. These can not be tested anyway
+            pass
+
+    return tests
+
+

--- a/binder/tests_discoverer.py
+++ b/binder/tests_discoverer.py
@@ -4,14 +4,12 @@ from django.apps import apps
 # This prevents discoverer from loading models and views, which will
 # cause all sorts of random failures.
 def load_tests(loader, tests, pattern):
-    print("DISCOVER TESTS")
     for app in apps.get_app_configs():
         app_path = app.path
         test_dir = '{}/tests/'.format(app_path)
         try:
             if is_discoverable(test_dir):
                 tests.addTests(loader.discover(test_dir))
-                print("Discover tests for app ", app.verbose_name)
         except AssertionError:
             # This is thrown if the app is loaded from the venv. These can not be tested anyway
             pass

--- a/binder/tests_discoverer.py
+++ b/binder/tests_discoverer.py
@@ -15,5 +15,3 @@ def load_tests(loader, tests, pattern):
             pass
 
     return tests
-
-

--- a/binder/views.py
+++ b/binder/views.py
@@ -831,7 +831,10 @@ class ModelView(View):
 		queryset = self.order_by(queryset, request)
 
 		if not pk:
-			meta['total_records'] = queryset.count()
+			# Only 'pk' values should reduce DB server memory a (little?) bit, making
+			# things faster.  Not prefetching related models here makes it faster still.
+			# See also https://code.djangoproject.com/ticket/23771 and related tickets.
+			meta['total_records'] = queryset.prefetch_related(None).values('pk').count()
 
 		queryset = self._paginate(queryset, request)
 

--- a/binder/views.py
+++ b/binder/views.py
@@ -1000,6 +1000,11 @@ class ModelView(View):
 		if validation_errors:
 			raise sum(validation_errors, None)
 
+		# Skip re-fetch and serialization via get_objs if we're in
+		# multi-put (data is discarded!).
+		if getattr(request, '_is_multi_put', False):
+			return None
+
 		# Permission checks are done at this point, so we can avoid get_queryset()
 		data = self._get_objs(
 			annotate(self.model.objects.filter(pk=obj.pk)),
@@ -1421,6 +1426,10 @@ class ModelView(View):
 
 	def multi_put(self, request):
 		logger.info('ACTIVATING THE MULTI-PUT!!!1!')
+
+		# Hack to communicate to _store() that we're not interested in
+		# the new data (for perf reasons).
+		request._is_multi_put = True
 
 		data = self._multi_put_parse_request(request)
 		objects = self._multi_put_collect_objects(data)


### PR DESCRIPTION
Automatically imports all unittests, so that it doesn't need to be done manually.

How it works:
in main/tests/__init__.py add the following:

 - `from binder import load_tests`
 - ???
 - Profit

A bit deeper how it works:
- This loads all the apps in binder
- It tries to see if the tests/ directory exists
- If it exists, it automatically loads all the tests

Does not run the tests on apps that are not in the app directory