### PR TITLE
Automatic views importing in router

### DIFF
--- a/binder/router.py
+++ b/binder/router.py
@@ -1,6 +1,10 @@
+from importlib import import_module
+
 import django
+from django.apps import apps
 from django.urls import reverse
 
+from binder.views import ModelView
 from .exceptions import BinderRequestError, BinderCSRFFailure, BinderMethodNotAllowed
 
 
@@ -53,6 +57,22 @@ class Route(object):
 
 
 class Router(object):
+
+	@staticmethod
+	def bootstrap():
+		me = Router()
+
+		# import all views
+		for app in apps.get_app_configs():
+			try:
+				import_module('.views', app.name)
+			except ImportError:
+				# No views to be imported for this app
+				pass
+		me.register(ModelView)
+		return me
+
+
 	def __init__(self):
 		self.model_views = {}
 		self.model_routes = {}


### PR DESCRIPTION
Old:
```
from binder.router import Router
from binder.views import ModelView

# needed for binder.router to work
import cyrm.views  # noqa
import base.orders.views  # noqa
import ib.ib_orders.views  # noqa
....
import base.planning.views # noqa

router = Router().register(ModelView)

api_urls = [
    re_path('^', include(router.urls)),
]

```

New:
```
from binder.router import Router
router = Router.bootstrap()
api_urls = [
    re_path('^', include(router.urls)),
]
```

