### PR TITLE
[WIP] Refactor _filter_field and _filter_relation to return Q objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 The `_filter_field` method now returns a `Q()` object, not a queryset.
 Similarly, the `_filter_relation` method no longer accepts a queryset
-and now returns a `Q()` object and a boolean indicating if the master
-query should be made distinct.
+and now returns a new namedtuple called `FilterDescription`, which
+contains a `Q()` object property called `filter` and a boolean called
+`need_distinct` which indicated if the master query should be made
+distinct.
 
 Using `Q()` objects instead of querysets allows making queries in
 `with_ids` without requiring a subquery on filtered relations, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## HEAD
+
+### Breaking changes
+
+The `_filter_field` method now returns a `Q()` object, not a queryset.
+Similarly, the `_filter_relation` method no longer accepts a queryset
+and now returns a `Q()` object and a boolean indicating if the master
+query should be made distinct.
+
+Using `Q()` objects instead of querysets allows making queries in
+`with_ids` without requiring a subquery on filtered relations, which
+can be a big performance win on large tables.
+
 ## Version 1.4.0
 
 ### Features

--- a/binder/views.py
+++ b/binder/views.py
@@ -637,12 +637,12 @@ class ModelView(View):
 		for field in with_map:
 			vr = self.virtual_relations.get(field, None)
 
-			next = self._follow_related(field)[0]
-			view_class = self.router.model_view(next.model)
+			next_relation = self._follow_related(field)[0]
+			view_class = self.router.model_view(next_relation.model)
 			view = view_class()
 			# {router-view-instance}
 			view.router = self.router
-			q, _ = view._filter_relation(None if vr else next.fieldname, where_map.get(field, None))
+			q, _ = view._filter_relation(None if vr else next_relation.fieldname, where_map.get(field, None))
 
 			# Model default orders (this sometimes matters)
 			orders = []

--- a/binder/views.py
+++ b/binder/views.py
@@ -635,18 +635,14 @@ class ModelView(View):
 		Agg = GroupConcat if connections[self.model.objects.db].vendor == 'mysql' else OrderableArrayAgg
 
 		for field in with_map:
-			next = self._follow_related(field)[0].model
-			view_class = self.router.model_view(next)
+			vr = self.virtual_relations.get(field, None)
+
+			next = self._follow_related(field)[0]
+			view_class = self.router.model_view(next.model)
 			view = view_class()
 			# {router-view-instance}
 			view.router = self.router
-			qs = view._filter_relation(next, where_map.get(field, None))
-			# Drop ordering in subquery.  Can be slightly faster; we
-			# add ordering to the array_agg call already anyway.
-			if qs:
-				qs = qs.order_by()
-
-			vr = self.virtual_relations.get(field, None)
+			q, _ = view._filter_relation(None if vr else next.fieldname, where_map.get(field, None))
 
 			# Model default orders (this sometimes matters)
 			orders = []
@@ -673,7 +669,6 @@ class ModelView(View):
 				# This does mean you can't filter on this relation
 				# unless you write a custom filter, too.
 				if isinstance(virtual_annotation, Q):
-					q = Q(**{field+'__in': qs}) if qs else Q()
 					annotations[field_alias] = Agg(virtual_annotation, filter=q, ordering=orders)
 				else:
 					try:
@@ -682,14 +677,13 @@ class ModelView(View):
 						raise BinderRequestError('Annotation for virtual relation {{{}}}.{{{}}} is {{{}}}, but no method by that name exists.'.format(
 							self.model.__name__, field, virtual_annotation
 						))
-					rel_ids_by_field_by_id[field] = func(request, pks, Q(pk__in=qs) if qs else Q())
+					rel_ids_by_field_by_id[field] = func(request, pks, q)
 			# Actual relation
 			else:
 				if (getattr(self.model, field).__class__ == models.fields.related.ReverseOneToOneDescriptor or
 					not any(f.name == field for f in (list(self.model._meta.many_to_many) + list(self._get_reverse_relations())))):
 					singular_fields.add(field)
 
-				q = Q(**{field+'__in': qs}) if qs is not None else Q()
 				if Agg != GroupConcat: # HACKK (GROUP_CONCAT can't filter and excludes NULL already)
 					q &= Q(**{field+'__pk__isnull': False})
 				annotations[field_alias] = Agg(field+'__pk', filter=q, ordering=orders)
@@ -751,24 +745,28 @@ class ModelView(View):
 	# should be scoped on, but also a set of wheres where model M
 	# should further be scoped on.
 	#
-	# Returns a queryset for this field we should filter on further.
-	def _filter_relation(self, M, where_map):
+	# Returns a Q object for this field we should filter on further.
+	def _filter_relation(self, field_name, where_map):
 		# If there are no filters, do nothing
 		if where_map is None:
-			return None
+			return Q(), False
 
 		wheres = where_map['filters']
 
-		qs = annotate(M.objects.all())
+		q = Q()
+		need_distinct = False
 		for where in wheres:
 			field, val = where.split('=')
-			qs = self._parse_filter(qs, field, val)
+			new_q, distinct = self._parse_filter(field, val, field_name+'__' if field_name else '')
+			need_distinct |= distinct
+			q &= new_q
 
-		return qs
+		return q, need_distinct
 
 
-	def _parse_filter(self, queryset, field, value, partial=''):
+	def _parse_filter(self, field, value, partial=''):
 		head, *tail = field.split('.')
+		need_distinct = False
 
 		if not tail:
 			invert = False
@@ -783,7 +781,9 @@ class ModelView(View):
 			except ValueError:
 				qualifier = None
 
-			queryset = self._filter_field(queryset, head, qualifier, value, invert, partial)
+			q = self._filter_field(head, qualifier, value, invert, partial)
+		else:
+			q = Q()
 
 		try:
 			related = self._follow_related(head)[0]
@@ -798,27 +798,30 @@ class ModelView(View):
 			view = self.router.model_view(related.model)()
 			# {router-view-instance}
 			view.router = self.router
-			queryset = view._parse_filter(queryset, '.'.join(tail), value, partial + head + '__')
-			# Distinct might be needed when we traverse a relation
-			# that is joined in, as it may produce duplicate records.
-			# Always doing the distinct works, but has performance
-			# implications, hence we avoid it if possible.
+			new_q, distinct = view._parse_filter('.'.join(tail), value, partial + head + '__')
+			need_distinct |= distinct
+			q &= new_q
 
+		# Distinct might be needed when we traverse a relation
+		# that is joined in, as it may produce duplicate records.
+		# Always doing the distinct works, but has performance
+		# implications, hence we avoid it if possible.
 		if related is not None:
 			related_field = getattr(self.model, related.fieldname)
 			if isinstance(related_field, models.fields.related.ReverseManyToOneDescriptor): # m2m or reverse fk
-				queryset = queryset.distinct()
-		return queryset
+				need_distinct = True
+
+		return q, need_distinct
 
 
 
-	def _filter_field(self, queryset, field_name, qualifier, value, invert, partial=''):
+	def _filter_field(self, field_name, qualifier, value, invert, partial=''):
 		if field_name in self.annotations:
 			if partial:
-				return queryset.filter(**{partial + 'in': self._filter_field(
-					annotate(self.model.objects.all()),
-					field_name, qualifier, value, invert,
-				)})
+				# NOTE: This creates a subquery; try to avoid this!
+				qs = annotate(self.model.objects.all())
+				qs = qs.filter(self._filter_field(field_name, qualifier, value, invert))
+				return Q(**{partial + 'in': qs})
 			field = self.annotations[field_name]['field']
 		else:
 			try:
@@ -833,7 +836,7 @@ class ModelView(View):
 			if filter_class:
 				filter = filter_class(field)
 				try:
-					return queryset.filter(filter.get_q(qualifier, value, invert, partial))
+					return filter.get_q(qualifier, value, invert, partial)
 				except ValidationError as e:
 					# TODO: Maybe convert to a BinderValidationError later?
 					raise BinderRequestError(e.message)
@@ -1041,7 +1044,10 @@ class ModelView(View):
 		filters = {k.lstrip('.'): v for k, v in request.GET.lists() if k.startswith('.')}
 		for field, values in filters.items():
 			for v in values:
-				queryset = self._parse_filter(queryset, field, v)
+				q, distinct = self._parse_filter(field, v)
+				queryset = queryset.filter(q)
+				if distinct:
+					queryset = queryset.distinct()
 
 		#### search
 		if 'search' in request.GET:


### PR DESCRIPTION
This avoids requiring a subquery in the with_ids array_agg call.
Without a subselect, things are a lot faster!

There are a few situations in virtual relations where this is not the
best way, but not many projects use virtual relations and most of
these cases can be worked around in Django 3 due to being able to
filter on boolean expressions anyway...