### PR TITLE
Make read only error a bit stricter

### DIFF
--- a/binder/views.py
+++ b/binder/views.py
@@ -1305,6 +1305,7 @@ class ModelView(View):
 		if field in [
 			'id', 'pk', 'deleted', '_meta',
 			*self.unwritable_fields,
+			*self.shown_properties,
 			*self.file_fields,
 			*self.annotations,
 		]:

--- a/binder/views.py
+++ b/binder/views.py
@@ -1302,7 +1302,12 @@ class ModelView(View):
 	# Otherwise, return False.
 	def _store_field(self, obj, field, value, request, pk=None):
 		# Unwritable fields
-		if field in self.unwritable_fields + ['id', 'pk', 'deleted', '_meta'] + self.file_fields:
+		if field in [
+			'id', 'pk', 'deleted', '_meta',
+			*self.unwritable_fields,
+			*self.file_fields,
+			*self.annotations,
+		]:
 			raise BinderReadOnlyFieldError(self.model.__name__, field)
 
 		# Regular fields and FKs


### PR DESCRIPTION
So @abzainuddin and me thought that some fields were automatically ignored by binder. Apparantly they were not but there is a read only field error. However some additions from that were missing.

I think ignoring them is not necessary anymore as of https://github.com/CodeYellowBV/mobx-spine/pull/80 since we can now more easily handle which fields get sent on the frontend.