### PR TITLE
Fix userview _parse_filter, which currently is broken and thus breaks binder

### DIFF
--- a/binder/plugins/views/userview.py
+++ b/binder/plugins/views/userview.py
@@ -369,7 +369,7 @@ class UserViewMixIn(UserBaseMixin):
 
 		Request:
 
-		POST user/{id}/activate/
+		PUT user/{id}/activate/
 		{
 			"activation_code": string
 		}
@@ -400,7 +400,7 @@ class UserViewMixIn(UserBaseMixin):
 			user = self.model._default_manager.get(pk=pk)
 		except (TypeError, ValueError, OverflowError, self.model.DoesNotExist):
 			user = None
-
+		print(body.get('activation_code'))
 		if user is None or not self.token_generator.check_token(user, body.get('activation_code')):
 			raise BinderNotFound()
 

--- a/binder/plugins/views/userview.py
+++ b/binder/plugins/views/userview.py
@@ -116,10 +116,11 @@ class UserViewMixIn(UserBaseMixin):
 				Q(user_permissions__codename=value) |
 				Q(is_superuser=True)
 			)
+			# if there is not a partial search (icontains, startswith, in) we just look for the private key
 			if not partial:
 				partial = 'pk__'
 			# Second false means the userview is not distinct, this means that while some information may be sent twice
-			# (because two users have a relation to the same thing) we never m 	iss information.
+			# (because two users have a relation to the same thing) we never miss information.
 			return Q(**{partial + 'in': set(users.values_list('id', flat=True))}), False
 		else:
 			return super()._parse_filter(field, value, partial)

--- a/binder/plugins/views/userview.py
+++ b/binder/plugins/views/userview.py
@@ -105,26 +105,6 @@ class UserViewMixIn(UserBaseMixin):
 		except BinderForbidden:  # convert to read-only error, so the field is ignored
 			raise BinderReadOnlyFieldError(self.model.__name__, field)
 
-	def _parse_filter(self,  field, value, partial=''):
-		"""
-		Add the has_permission as a filter
-		Partial here is a partial lookup, aka icontains__, in__, startwith__ see doc api for further explanation
-		"""
-		if field == 'has_permission':
-			users = self.model.objects.filter(
-				Q(groups__permissions__codename=value) |
-				Q(user_permissions__codename=value) |
-				Q(is_superuser=True)
-			)
-			# if there is not a partial search (icontains, startswith, in) we just look for the private key
-			if not partial:
-				partial = 'pk__'
-			# Second false means the userview is not distinct, this means that while some information may be sent twice
-			# (because two users have a relation to the same thing) we never miss information.
-			return Q(**{partial + 'in': set(users.values_list('id', flat=True))}), False
-		else:
-			return super()._parse_filter(field, value, partial)
-
 	def authenticate(self, request, **kwargs):
 		return auth.authenticate(request, **kwargs)
 

--- a/binder/plugins/views/userview.py
+++ b/binder/plugins/views/userview.py
@@ -105,7 +105,7 @@ class UserViewMixIn(UserBaseMixin):
 		except BinderForbidden:  # convert to read-only error, so the field is ignored
 			raise BinderReadOnlyFieldError(self.model.__name__, field)
 
-	def _parse_filter(self, queryset, field, value, partial=''):
+	def _parse_filter(self,  field, value, partial=''):
 		"""
 		Add the has_permission as a filter
 		"""
@@ -116,10 +116,10 @@ class UserViewMixIn(UserBaseMixin):
 				Q(is_superuser=True)
 			)
 			if not partial:
-				return users
-			return queryset.filter(Q(**{partial + 'in': set(users.values_list('id', flat=True))}))
+				partial = 'pk__'
+			return Q(**{partial + 'in': set(users.values_list('id', flat=True))}), False
 		else:
-			return super()._parse_filter(queryset, field, value, partial)
+			return super()._parse_filter(field, value, partial)
 
 	def authenticate(self, request, **kwargs):
 		return auth.authenticate(request, **kwargs)

--- a/binder/plugins/views/userview.py
+++ b/binder/plugins/views/userview.py
@@ -108,6 +108,7 @@ class UserViewMixIn(UserBaseMixin):
 	def _parse_filter(self,  field, value, partial=''):
 		"""
 		Add the has_permission as a filter
+		Partial here is a partial lookup, aka icontains__, in__, startwith__ see doc api for further explanation
 		"""
 		if field == 'has_permission':
 			users = self.model.objects.filter(

--- a/binder/plugins/views/userview.py
+++ b/binder/plugins/views/userview.py
@@ -118,6 +118,8 @@ class UserViewMixIn(UserBaseMixin):
 			)
 			if not partial:
 				partial = 'pk__'
+			# Second false means the userview is not distinct, this means that while some information may be sent twice
+			# (because two users have a relation to the same thing) we never m 	iss information.
 			return Q(**{partial + 'in': set(users.values_list('id', flat=True))}), False
 		else:
 			return super()._parse_filter(field, value, partial)

--- a/binder/plugins/views/userview.py
+++ b/binder/plugins/views/userview.py
@@ -400,7 +400,6 @@ class UserViewMixIn(UserBaseMixin):
 			user = self.model._default_manager.get(pk=pk)
 		except (TypeError, ValueError, OverflowError, self.model.DoesNotExist):
 			user = None
-		print(body.get('activation_code'))
 		if user is None or not self.token_generator.check_token(user, body.get('activation_code')):
 			raise BinderNotFound()
 

--- a/binder/plugins/views/userview.py
+++ b/binder/plugins/views/userview.py
@@ -6,7 +6,6 @@ from django.contrib import auth
 from django.contrib.auth import update_session_auth_hash, password_validation
 from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import ValidationError
-from django.db.models import Q
 from django.http import HttpResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.debug import sensitive_post_parameters

--- a/tests/plugins/test_userview.py
+++ b/tests/plugins/test_userview.py
@@ -1,11 +1,17 @@
+from datetime import datetime, timedelta, date
 from unittest.mock import patch
 
 from django.contrib.auth.models import User
 from django.contrib.auth.tokens import default_token_generator
-from django.test import TestCase, Client
+from django.test import TestCase, Client, override_settings
+from binder.plugins.token_auth.models import Token
 
 import json
-from binder.json import JsonResponse
+
+from django.contrib.auth.tokens import default_token_generator
+from django.utils.http import base36_to_int, int_to_base36
+from binder.json import JsonResponse, jsonloads
+from tests.testapp.models import ContactPerson, Zoo, Animal
 
 
 @patch(
@@ -22,10 +28,78 @@ class UserPasswordResetTestCase(TestCase):
 	def test_reset_call(self, reset_mock):
 		client = Client()
 		res = client.put('/user/{}/reset_password/'.format(self.user.pk), json.dumps({
-				'reset_code': self.token,
-				'password': 'foobar',
-			}))
+			'reset_code': self.token,
+			'password': 'foobar',
+		}))
 
 		self.assertEqual(200, res.status_code)
 
 		reset_mock.assert_called_once_with(res.wsgi_request, self.user.pk, self.token, 'foobar')
+
+
+class UserLogic(TestCase):
+
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='foo', password='bar', is_active=True, is_superuser=True)
+		self.user.save()
+		self.user2 = User.objects.create_user(id=7, username='test', password='user', is_active=False)
+		self.user2.save()
+		self.token = default_token_generator.make_token(self.user2)
+
+	def test_user_login(self):
+		self.client = Client()
+		r = self.client.login(username='foo', password='bar')
+		self.assertTrue(r)
+
+	def test_user_login_wrong_password(self):
+		self.client = Client()
+		r = self.client.login(username='foo', password='wrong_pass')
+		self.assertFalse(r)
+
+	def test_user_activation(self):
+		self.client = Client()
+
+		data = {
+			"activation_code": (str(self.token))
+		}
+
+		r = self.client.put('/user/7/activate/', data=json.dumps(data),
+							content_type='application/json')
+		result = jsonloads(r.content)
+		print(result)
+
+		self.assertEqual(200, r.status_code)
+
+
+class UserFilterParseTest(TestCase):
+
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='foo', password='bar', is_active=True, is_superuser=True)
+		self.user.save()
+		self.token = default_token_generator.make_token(self.user)
+		self.client = Client()
+		r = self.client.login(username='foo', password='bar')
+		self.assertTrue(r)
+		z = Zoo(id=1, name='zoo')
+		z2 = Zoo(id=2, name='zoo2')
+		z.save()
+		z2.save()
+		Animal(id=1, name='animal', zoo_id=1).save()
+		Animal(id=2, name='animal2', zoo_id=1).save()
+		Animal(id=3, name='animal2', zoo_id=2).save()
+
+	def test_parse_filter(self):
+		response = self.client.get('/animal/?with=zoo&limit=25&order_by=-name&.name=animal2&.zoo.name=zoo')
+		self.assertEqual(200, response.status_code)
+		result = jsonloads(response.content)
+		expected_result = [{'name': 'animal2', 'zoo': 1, 'zoo_of_birth': None, 'caretaker': None, 'deleted': False,
+							'id': 2, 'costume': None}]
+		self.assertEqual(expected_result, result['data'])
+
+	def test_parse_filter_should_be_empty(self):
+		response = self.client.get('/animal/?with=zoo&limit=25&order_by=-name&.name=non_existent_animal&.zoo.name=zoo')
+		self.assertEqual(200, response.status_code)
+		result = jsonloads(response.content)
+		self.assertEqual([], result['data'])

--- a/tests/plugins/test_userview.py
+++ b/tests/plugins/test_userview.py
@@ -93,7 +93,7 @@ class UserFilterParseTest(TestCase):
 	def test_parse_filter_userview_with_only_has_permission(self):
 		result = self.client.get('/user/?.has_permission=foo.bar')
 		self.assertEqual(200, result.status_code)
-		result_json = json.loads(result.content)
+		result_json = json.loads(result.content.decode('utf-8'))
 		self.assertEqual(result_json['data'][0]['username'], 'bar')
 
 
@@ -108,7 +108,7 @@ class UserFilterParseTest(TestCase):
 	def test_parse_filter_userview_with_has_permission_and_partial(self):
 		result = self.client.get('/user/?.has_permission=foo.bar&.username:icontains=tes')
 		self.assertEqual(200, result.status_code)
-		result_json = json.loads(result.content)
+		result_json = json.loads(result.content.decode('utf-8'))
 		self.assertEqual(result_json['data'][0]['username'], 'test')
 
 	@override_settings(BINDER_PERMISSION={
@@ -119,5 +119,5 @@ class UserFilterParseTest(TestCase):
 	def test_parse_filter_userview_without_has_permission(self):
 		result = self.client.get('/user/?.username=test')
 		self.assertEqual(200, result.status_code)
-		result_json = json.loads(result.content)
+		result_json = json.loads(result.content.decode('utf-8'))
 		self.assertEqual(result_json['data'][0]['username'], 'test')

--- a/tests/testapp/views/user.py
+++ b/tests/testapp/views/user.py
@@ -8,7 +8,7 @@ from binder.plugins.views import UserViewMixIn
 from binder.router import list_route
 
 
-class UserView(PermissionView, UserViewMixIn):
+class UserView(UserViewMixIn, PermissionView):
 	model = User
 
 	hidden_fields = ['password', 'is_staff', 'date_joined']


### PR DESCRIPTION
Due to changes in _parse_filter in both userview and general view which different and not compatible atm binder is broken. 
This PR adds tests for the functionality and fixes the issue, it does assume that the userview never has to have distinct elements. This is less optimized then detecting when distinct can be used but does ensure all data is sent that is needed.