### PR TITLE
Add RabbitMq support for HT

### DIFF
--- a/binder/websocket.py
+++ b/binder/websocket.py
@@ -1,47 +1,58 @@
 from django.conf import settings
+
 from .json import jsondumps
 import requests
 from requests.exceptions import RequestException
 
+
 class RoomController(object):
-	def __init__(self):
-		self.room_listings = []
+    def __init__(self):
+        self.room_listings = []
 
-	def register(self, superclass):
-		for view in superclass.__subclasses__():
-			if view.register_for_model and view.model is not None:
-				listing = getattr(view, 'get_rooms_for_user', None)
+    def register(self, superclass):
+        for view in superclass.__subclasses__():
+            if view.register_for_model and view.model is not None:
+                listing = getattr(view, 'get_rooms_for_user', None)
 
-				if listing and callable(listing):
-					self.room_listings.append(listing)
+                if listing and callable(listing):
+                    self.room_listings.append(listing)
 
-			self.register(view)
+            self.register(view)
 
-		return self
+        return self
 
-	def list_rooms_for_user(self, user):
-		rooms = []
+    def list_rooms_for_user(self, user):
+        rooms = []
 
-		for l in self.room_listings:
-			rooms += l(user)
+        for l in self.room_listings:
+            rooms += l(user)
 
-		return rooms
+        return rooms
 
 
 def trigger(data, rooms):
-	import pika
-	from pika import BlockingConnection
-	from django.conf import settings
-	import json
+    if 'rabbitmq' in getattr(settings, 'HIGH_TEMPLAR', {}):
+        import pika
+        from pika import BlockingConnection
+        import json
 
-	connection_credentials = pika.PlainCredentials(settings.HIGH_TEMPLAR['rabbitmq']['username'],
-												   settings.HIGH_TEMPLAR['rabbitmq']['password'])
-	connection_parameters = pika.ConnectionParameters(settings.HIGH_TEMPLAR['rabbitmq']['host'],
-													  credentials=connection_credentials)
-	connection = BlockingConnection(parameters=connection_parameters)
-	channel = connection.channel()
+        connection_credentials = pika.PlainCredentials(settings.HIGH_TEMPLAR['rabbitmq']['username'],
+                                                       settings.HIGH_TEMPLAR['rabbitmq']['password'])
+        connection_parameters = pika.ConnectionParameters(settings.HIGH_TEMPLAR['rabbitmq']['host'],
+                                                          credentials=connection_credentials)
+        connection = BlockingConnection(parameters=connection_parameters)
+        channel = connection.channel()
 
-	channel.basic_publish('hightemplar', routing_key='*', body=jsondumps({
-		'data': data,
-		'rooms': rooms,
-	}))
+        channel.basic_publish('hightemplar', routing_key='*', body=jsondumps({
+            'data': data,
+            'rooms': rooms,
+        }))
+    if getattr(settings, 'HIGH_TEMPLAR_URL', None):
+        url = getattr(settings, 'HIGH_TEMPLAR_URL')
+        try:
+            requests.post('{}/trigger/'.format(url), data=jsondumps({
+                'data': data,
+                'rooms': rooms,
+            }))
+        except RequestException:
+            pass

--- a/binder/websocket.py
+++ b/binder/websocket.py
@@ -34,7 +34,6 @@ def trigger(data, rooms):
     if 'rabbitmq' in getattr(settings, 'HIGH_TEMPLAR', {}):
         import pika
         from pika import BlockingConnection
-        import json
 
         connection_credentials = pika.PlainCredentials(settings.HIGH_TEMPLAR['rabbitmq']['username'],
                                                        settings.HIGH_TEMPLAR['rabbitmq']['password'])

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -6,6 +6,7 @@ from .testapp.urls import room_controller
 from .testapp.models import Animal, Costume
 import requests
 import json
+from django.test import override_settings
 
 
 class MockUser:
@@ -46,6 +47,7 @@ class WebsocketTest(TestCase):
 		self.assertCountEqual(allowed_rooms, rooms)
 
 	@mock.patch('requests.post', side_effect=mock_post_high_templar)
+	@override_settings(HIGH_TEMPLAR_URL="http://localhost:8002")
 	def test_post_save_trigger(self, mock):
 		doggo = Animal(name='Woofer')
 		doggo.full_clean()


### PR DESCRIPTION
Allows to set RabbitMQ settings for the HT triggers

Breaking change: 
- HIGH_TEMPLAR_URL needs to be set in order for old HT messages to be triggered