### PR TITLE
Abstract AggStrategy to make it extensible

### DIFF
--- a/binder/views.py
+++ b/binder/views.py
@@ -191,6 +191,10 @@ class ModelView(View):
 	#  }
 	virtual_relations = {}
 
+	@property
+	def AggStrategy(self):
+		return GroupConcat if connections[self.model.objects.db].vendor == 'mysql' else OrderableArrayAgg
+
 
 	@property
 	def annotations(self):
@@ -631,7 +635,7 @@ class ModelView(View):
 		rel_ids_by_field_by_id = defaultdict(lambda: defaultdict(list))
 		virtual_fields = set()
 
-		Agg = GroupConcat if connections[self.model.objects.db].vendor == 'mysql' else OrderableArrayAgg
+		Agg = self.AggStrategy
 
 		for field in with_map:
 			vr = self.virtual_relations.get(field, None)


### PR DESCRIPTION
This allows the AggStrategy to be set by the application in case of another database then mysql or postgres (In this particular case Mssql)