### PR TITLE
Add option to ignore certain permissions in define groups

### DIFF
--- a/binder/management/commands/define_groups.py
+++ b/binder/management/commands/define_groups.py
@@ -5,56 +5,72 @@ from django.utils.translation import ugettext as _
 from django.contrib.auth.models import Group, Permission, ContentType
 
 
+def parse_perm(perm_name):
+	try:
+		app, other = perm_name.split('.')
+		if ':' in other:
+			action_and_model, scope = other.split(':')
+		else:
+			action_and_model = other
+		action, model = action_and_model.split('_')
+
+		content_type = ContentType.objects.get(
+			app_label=app,
+			model=model,
+		)
+
+		return Permission.objects.get(
+			content_type=content_type,
+			codename=other,
+		)
+	except ContentType.DoesNotExist:
+		raise RuntimeError(
+			'Model for ' + perm_name + ' does not exist'
+		)
+	except Permission.DoesNotExist:
+		raise RuntimeError(
+			'Permission ' + perm_name + ' does not exist'
+		)
+
+
 class Command(BaseCommand):
-    help = _('Define user groups/roles to their required specifications')
+	help = _('Define user groups/roles to their required specifications')
 
-    @transaction.atomic
-    def handle(self, *args, **options):
-        # Delete any stale groups
+	@transaction.atomic
+	def handle(self, *args, **options):
+		# Collect all permissions that this command should ignore
+		# We only need the pks
+		ignored_perm_pks = {
+			parse_perm(perm_name).pk
+			for perm_name in getattr(settings, 'GROUP_IGNORED_PERMISSIONS', [])
+		}
 
-        Group.objects.exclude(name__in=settings.GROUP_PERMISSIONS).delete()
+		# Delete any stale groups
+		Group.objects.exclude(name__in=settings.GROUP_PERMISSIONS).delete()
 
-        for group_name in settings.GROUP_PERMISSIONS:
-            group, _ = Group.objects.get_or_create(name=group_name)
+		for group_name in settings.GROUP_PERMISSIONS:
+			group, _ = Group.objects.get_or_create(name=group_name)
 
-            # Get all groups that are contained by this group
-            groups_to_expand = [group_name]
-            groups = set()
-            while groups_to_expand:
-                group_name = groups_to_expand.pop()
-                if group_name not in groups:
-                    groups.add(group_name)
-                    groups_to_expand.extend(settings.GROUP_CONTAINS.get('group_name', []))
+			# Get all groups that are contained by this group
+			groups_to_expand = [group_name]
+			groups = set()
+			while groups_to_expand:
+				group_name = groups_to_expand.pop()
+				if group_name not in groups:
+					groups.add(group_name)
+					groups_to_expand.extend(
+						getattr(settings, 'GROUP_CONTAINS', {})
+						.get(group_name, [])
+					)
 
-            # Collect all permissions for these groups
-            perms = set()
-            for group_name in groups:
-                for perm_name in settings.GROUP_PERMISSIONS[group_name]:
-                    try:
-                        app, other = perm_name.split('.')
-                        if ':' in other:
-                            action_and_model, scope = other.split(':')
-                        else:
-                            action_and_model = other
-                        action, model = action_and_model.split('_')
+			# Collect all permissions for these groups
+			perms = {
+				parse_perm(perm_name)
+				for group_name in groups
+				for perm_name in settings.GROUP_PERMISSIONS[group_name]
+			}
+			# Add all permissions that are ignored by this command that the
+			# group already has
+			perms.update(group.permissions.filter(pk__in=ignored_perm_pks))
 
-                        content_type = ContentType.objects.get(
-                            app_label=app,
-                            model=model,
-                        )
-
-                        perm = Permission.objects.get(
-                            content_type=content_type,
-                            codename=other,
-                        )
-                        perms.add(perm)
-                    except ContentType.DoesNotExist:
-                        raise RuntimeError(
-                            'Model for ' + perm_name + ' does not exist'
-                        )
-                    except Permission.DoesNotExist:
-                        raise RuntimeError(
-                            'Permission ' + perm_name + ' does not exist'
-                        )
-
-            group.permissions.set(perms)
+			group.permissions.set(perms)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -121,7 +121,15 @@ cmd.sync_apps(connection, executor.loader.unmigrated_apps)
 
 # Hack to make the view_country permission, which doesn't work with the MigrationCommand somehow
 from django.contrib.auth.models import Group, Permission, ContentType
-content_type = ContentType.objects.get_or_create(app_label='testapp', model='country')[0]
-Permission.objects.get_or_create(content_type=content_type, codename='view_country')
-call_command('define_groups')
+for model in ['country', 'animal', 'zooemployee']:
+	content_type, _ = ContentType.objects.get_or_create(
+		app_label='testapp',
+		model=model,
+	)
+	for action in ['view', 'add', 'change', 'delete']:
+		Permission.objects.get_or_create(
+			content_type=content_type,
+			codename=f'{action}_{model}',
+		)
 
+call_command('define_groups')

--- a/tests/test_define_groups.py
+++ b/tests/test_define_groups.py
@@ -51,9 +51,6 @@ class TestDefineGroups(TestCase):
 		],
 	)
 	def test_basic_groups(self):
-		for ct in ContentType.objects.all():
-			print('CONTENT TYPE', ct.app_label, ct.model)
-
 		PERMS = {
 			'caretaker': [
 				'testapp.view_animal',

--- a/tests/test_define_groups.py
+++ b/tests/test_define_groups.py
@@ -1,0 +1,97 @@
+from django.core import management
+from django.contrib.auth.models import Group, ContentType, Permission
+from django.test import TestCase, override_settings
+
+
+class TestDefineGroups(TestCase):
+
+	def _test_define_groups(self, permissions):
+		management.call_command('define_groups')
+
+		seen_groups = set()
+		for group in Group.objects.all():
+			seen_groups.add(group.name)
+			group_permissions = {
+				f'{perm.content_type.app_label}.{perm.codename}'
+				for perm in group.permissions.all()
+			}
+			self.assertEqual(group_permissions, set(permissions[group.name]))
+
+		self.assertEqual(seen_groups, set(permissions))
+
+	@override_settings(
+		GROUP_PERMISSIONS={},
+		GROUP_CONTAINS={},
+		GROUP_IGNORED_PERMISSIONS=[],
+	)
+	def test_no_groups(self):
+		self._test_define_groups({})
+
+	@override_settings(
+		GROUP_PERMISSIONS={
+			'caretaker': [
+				'testapp.view_animal',
+				'testapp.add_animal',
+				'testapp.change_animal',
+				'testapp.delete_animal',
+			],
+			'hr': [
+				'testapp.view_zooemployee',
+				'testapp.add_zooemployee',
+				'testapp.change_zooemployee',
+				'testapp.delete_zooemployee',
+			],
+			'manager': {},
+		},
+		GROUP_CONTAINS={
+			'manager': ['caretaker', 'hr'],
+		},
+		GROUP_IGNORED_PERMISSIONS=[
+			'testapp.view_country',
+		],
+	)
+	def test_basic_groups(self):
+		for ct in ContentType.objects.all():
+			print('CONTENT TYPE', ct.app_label, ct.model)
+
+		PERMS = {
+			'caretaker': [
+				'testapp.view_animal',
+				'testapp.add_animal',
+				'testapp.change_animal',
+				'testapp.delete_animal',
+			],
+			'hr': [
+				'testapp.view_zooemployee',
+				'testapp.add_zooemployee',
+				'testapp.change_zooemployee',
+				'testapp.delete_zooemployee',
+			],
+			'manager': [
+				'testapp.view_animal',
+				'testapp.add_animal',
+				'testapp.change_animal',
+				'testapp.delete_animal',
+				'testapp.view_zooemployee',
+				'testapp.add_zooemployee',
+				'testapp.change_zooemployee',
+				'testapp.delete_zooemployee',
+			],
+		}
+		self._test_define_groups(PERMS)
+
+		# Test ignored permission remains after define groups
+		manager = Group.objects.get(name='manager')
+		view_country = Permission.objects.get(
+			content_type__app_label='testapp',
+			codename='view_country',
+		)
+		manager.permissions.add(view_country)
+
+		self._test_define_groups({
+			**PERMS,
+			'manager': [
+				*PERMS['manager'],
+				'testapp.view_country',
+			],
+		})


### PR DESCRIPTION
So for REX we do use the define groups functionality to define what groups have what permissions but I have now run into a use case where I need one permission that is assigned by the users instead of in the code. So what I did is add an optional setting `GROUP_IGNORED_PERMISSIONS` that contains a list of permissions that is ignored by the define groups command. (With ignored I mean that it does not change it's assignment, if it already was assigned to a group it will stay assigned, otherwise not.)