### PR TITLE
Add context aware annotations

### DIFF
--- a/binder/models.py
+++ b/binder/models.py
@@ -329,7 +329,7 @@ class ArrayFieldFilter(FieldFilter):
 			return []
 		else:
 			values = v.split(',')
-			return map(lambda v: filter.clean_value(qualifier, v), values)
+			return list(map(lambda v: filter.clean_value(qualifier, v), values))
 
 
 class JSONFieldFilter(FieldFilter):

--- a/binder/plugins/views/userview.py
+++ b/binder/plugins/views/userview.py
@@ -29,7 +29,7 @@ class UserBaseMixin:
 	def respond_with_user(self, request, user_id):
 		return JsonResponse(
 			self._get_objs(
-				annotate(self.get_queryset(request).filter(pk=user_id)),
+				annotate(self.get_queryset(request).filter(pk=user_id), request),
 				request=request,
 			)[0]
 		)

--- a/binder/views.py
+++ b/binder/views.py
@@ -56,7 +56,7 @@ def fix_output_field(expr, model):
 				fix_output_field(subexpr, model)
 
 
-def get_annotations(model, request):
+def get_annotations(model, request=None):
 	annotations = {}
 
 	if issubclass(model, BinderModel) and hasattr(model, 'Annotations'):
@@ -89,7 +89,7 @@ def get_annotations(model, request):
 	return annotations
 
 
-def annotate(qs, request):
+def annotate(qs, request=None):
 	for name, annotation in get_annotations(qs.model, request).items():
 		qs = qs.annotate(**{name: annotation['expr']})
 	return qs

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -139,3 +139,23 @@ class AnnotationTestCase(TestCase):
 
 		pks = {a['id'] for a in data['data']}
 		self.assertEqual(pks, animal_pks)
+
+	def test_context_annotation(self):
+		zoo = Zoo(name='Apenheul')
+		zoo.save()
+		harambe = Animal(zoo=zoo, name='Harambe')
+		harambe.save()
+		bokito = Animal(zoo=zoo, name='Bokito')
+		bokito.save()
+
+		res = self.client.get(f'/animal/{self.animal.pk}/')
+		self.assertEqual(res.status_code, 200)
+		data = jsonloads(res.content)
+		self.assertEqual(data['data']['name'], 'Harambe')
+		self.assertEqual(data['data']['prefixed_name'], 'Sir Harambe')
+
+		res = self.client.get(f'/animal/{self.animal.pk}/?animal_name_prefix=Lady')
+		self.assertEqual(res.status_code, 200)
+		data = jsonloads(res.content)
+		self.assertEqual(data['data']['name'], 'Harambe')
+		self.assertEqual(data['data']['prefixed_name'], 'Lady Harambe')

--- a/tests/test_set_nullable_relation.py
+++ b/tests/test_set_nullable_relation.py
@@ -19,6 +19,7 @@ class TestSetNullableRelations(TestCase):
 
         class FakeRequest:
             user = FakeUser()
+            GET = {}
 
         router = Router()
         router.register(AnimalView)
@@ -42,6 +43,7 @@ class TestSetNullableRelations(TestCase):
 
         class FakeRequest:
             user = FakeUser()
+            GET = {}
 
         router = Router()
         router.register(AnimalView)
@@ -65,6 +67,7 @@ class TestSetNullableRelations(TestCase):
 
         class FakeRequest:
             user = FakeUser()
+            GET = {}
 
         router = Router()
         router.register(AnimalView)

--- a/tests/testapp/models/animal.py
+++ b/tests/testapp/models/animal.py
@@ -1,7 +1,13 @@
 from django.db import models
-from binder.models import BinderModel
+from django.db.models import Value, F, Func
+from binder.models import BinderModel, ContextAnnotation
 from binder.exceptions import BinderValidationError
 from binder.plugins.loaded_values import LoadedValuesMixin
+
+
+class Concat(Func):
+	function = 'CONCAT'
+	output_field = models.TextField()
 
 # From the api docs: an animal with a name.
 class Animal(LoadedValuesMixin, BinderModel):
@@ -22,3 +28,9 @@ class Animal(LoadedValuesMixin, BinderModel):
 
 	class Binder:
 		history = True
+
+	class Annotations:
+		prefixed_name = ContextAnnotation(lambda request: Concat(
+			Value(request.GET.get('animal_name_prefix', 'Sir') + ' '),
+			F('name'),
+		))

--- a/tests/testapp/views/user.py
+++ b/tests/testapp/views/user.py
@@ -1,5 +1,8 @@
+from functools import partial
+
 from django.contrib.auth.models import User
-from django.db.models import Q
+from django.db import models
+from django.db.models import Q, Case, When, Value
 from django.http import HttpResponse
 
 from binder.json import jsondumps


### PR DESCRIPTION
This adds a wrapper `ContextAnnotation` that can be used to wrap a function that accepts a request object as it's only parameter and returns a Django query expression. This can be used to for example alter annotations based on the current user.

This PR does break a few things.
- A lot of methods now need the request object that previously did not, this however should be very trivial to migrate.
- The annotate function now requires a request object, we should see if this is often called outside of a request context in application code.