### PR TITLE
Get rid of workaround for complex sorting and replace it with a proper implementation

### DIFF
--- a/tests/test_order_by.py
+++ b/tests/test_order_by.py
@@ -1,7 +1,8 @@
 import unittest
 
-from django.db.models.functions import Abs, Upper, Reverse
+from django.db.models.functions import Abs, Upper, Reverse, Length
 from django.db.models import F
+from django.db.models.expressions import OrderBy
 from django.test import TestCase, Client
 from django.contrib.auth.models import User
 
@@ -230,8 +231,8 @@ class TestOrderBy(TestCase):
 
 		self.assertEqual(returned_data['data']['animals'], [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9])
 
-		# Complex order by with desc on an F field
-		with CustomOrdering(Animal, Upper(F('name')).desc(), '-id'):
+		# Complex order by with desc on an F field with an operation on it
+		with CustomOrdering(Animal, OrderBy(Length(F('name')), descending=True), '-name'):
 			response = self.client.get('/zoo/{}/?with=animals'.format(z.id))
 			self.assertEqual(response.status_code, 200)
 			returned_data = jsonloads(response.content)

--- a/tests/test_order_by.py
+++ b/tests/test_order_by.py
@@ -1,6 +1,7 @@
 import unittest
 
-from django.db.models.functions import Abs, Upper
+from django.db.models.functions import Abs, Upper, Reverse
+from django.db.models import F
 from django.test import TestCase, Client
 from django.contrib.auth.models import User
 
@@ -221,20 +222,29 @@ class TestOrderBy(TestCase):
 		self.assertEqual(returned_data['data']['animals'], [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9])
 
 
-		# This is a silly temporary test to ensure we don't crash on
-		# complex OrderBy expression.  We currently just skip these
-		# ordering components, with a warning.
-		#
-		# Looks like checking for logging is unreliable when the level
-		# is not high enough?!
-		#with self.assertLogs('warning'):
-		with CustomOrdering(Animal, 'name', Upper('name').asc()):
+		# Check ordering on complex OrderBy expression.
+		with CustomOrdering(Animal, Upper('name').asc(), '-id'):
 			response = self.client.get('/zoo/{}/?with=animals'.format(z.id))
 			self.assertEqual(response.status_code, 200)
 			returned_data = jsonloads(response.content)
 
 		self.assertEqual(returned_data['data']['animals'], [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9])
 
+		# Complex order by with desc on an F field
+		with CustomOrdering(Animal, Upper(F('name')).desc(), '-id'):
+			response = self.client.get('/zoo/{}/?with=animals'.format(z.id))
+			self.assertEqual(response.status_code, 200)
+			returned_data = jsonloads(response.content)
+
+		self.assertEqual(returned_data['data']['animals'], [a9, a8, a7, a6, a5, a4, a3, a2, a1, a0])
+
+		# Nested complex order by
+		with CustomOrdering(Animal, Reverse(Upper('name')), 'id'):
+			response = self.client.get('/zoo/{}/?with=animals'.format(z.id))
+			self.assertEqual(response.status_code, 200)
+			returned_data = jsonloads(response.content)
+
+		self.assertEqual(returned_data['data']['animals'], [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9])
 
 		with CustomOrdering(Animal, '-name'):
 			response = self.client.get('/zoo/{}/?with=animals'.format(z.id))


### PR DESCRIPTION
When fetching relations through "with", we used to skip complex
Meta.ordering expressions because they couldn't be prefixed with the
relation's name.

This implementation calls "deconstruct" from the deconstructible
decorator which is used on all serializable values.  Meta.ordering
must be serializable by definition, because it needs to usable in
migrations, so we can safely rely on that for the order by stuff.