### PR TITLE
Add decorators module

### DIFF
--- a/binder/decorators.py
+++ b/binder/decorators.py
@@ -1,0 +1,68 @@
+import time
+from functools import wraps
+
+import django
+from django.http.request import RawPostDataException
+from django.db import transaction
+
+from .views import ellipsize
+from .exceptions import BinderException
+
+
+def view_logger(logger, log_request_body=True):
+	def decorator(view):
+		@wraps(view)
+		def decorated(request, *args, **kwargs):
+			time_start = time.time()
+			logger.info('request dispatch; verb={}, user={}/{}, path={}'.format(
+				request.method,
+				request.user.id,
+				request.user,
+				request.path,
+			))
+			logger.info('remote_addr={}, X-Real-IP={}, X-Forwarded-For={}'.format(
+				request.META.get('REMOTE_ADDR', None),
+				request.META.get('HTTP_X_REAL_IP', None),
+				request.META.get('HTTP_X_FORWARDED_FOR', None),
+			))
+			logger.info('request parameters: {}'.format(dict(request.GET)))
+			logger.debug('cookies: {}'.format(request.COOKIES))
+
+			if not log_request_body:
+				body = ' censored.'
+			else:
+				# FIXME: ugly workaround, remove when Django bug fixed
+				# Try/except because https://code.djangoproject.com/ticket/27005
+				try:
+					if request.META.get('CONTENT_TYPE', '').lower() == 'application/json':
+						body = ': ' + ellipsize(request.body, length=65536)
+					else:
+						body = ': ' + ellipsize(request.body, length=64)
+				except RawPostDataException:
+					body = ' unavailable.'
+
+			logger.debug('body (content-type={}){}'.format(request.META.get('CONTENT_TYPE'), body))
+
+			response = view(request, *args, **kwargs)
+
+			logger.info('request response; status={} time={}ms bytes={} queries={}'.format(
+				response.status_code,
+				int((time.time() - time_start) * 1000),
+				'?' if response.streaming else len(response.content),
+				len(django.db.connection.queries),
+			))
+
+			return response
+		return decorated
+	return decorator
+
+
+def handle_exceptions(view):
+	@wraps(view)
+	def decorated(request, *args, **kwargs):
+		try:
+			with transaction.atomic():
+				return view(request, *args, **kwargs)
+		except BinderException as e:
+			return e.response(request)
+	return decorated

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -23,3 +23,8 @@ class HandleExceptionsTest(TestCase):
 		self.assertEqual(res.status_code, 418)
 
 		self.assertEqual(Zoo.objects.count(), 0)
+
+	def test_method_not_allowed(self):
+		client = Client()
+		res = client.post('/handle_exceptions/')
+		self.assertEqual(res.status_code, 405)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,25 @@
+from django.test import TestCase, Client
+
+from .testapp.models import Zoo
+
+
+class HandleExceptionsTest(TestCase):
+
+	def test_res(self):
+		self.assertEqual(Zoo.objects.count(), 0)
+
+		client = Client()
+		res = client.get('/handle_exceptions/', {'res': 'foo'})
+		self.assertEqual(res.status_code, 200)
+		self.assertEqual(res.content.decode(), 'foo')
+
+		self.assertEqual(Zoo.objects.count(), 1)
+
+	def test_err(self):
+		self.assertEqual(Zoo.objects.count(), 0)
+
+		client = Client()
+		res = client.get('/handle_exceptions/')
+		self.assertEqual(res.status_code, 418)
+
+		self.assertEqual(Zoo.objects.count(), 0)

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -8,6 +8,7 @@ import binder.models # noqa
 import binder.plugins.token_auth.views # noqa
 from binder.plugins.views.multi_request import multi_request_view
 from .views import animal, caretaker, costume, custom, zoo, contact_person, gate # noqa
+from .views.handle_exceptions import handle_exceptions_view
 
 router = binder.router.Router().register(binder.views.ModelView)
 room_controller = binder.websocket.RoomController().register(binder.views.ModelView)
@@ -16,6 +17,7 @@ urlpatterns = [
 	url(r'^custom/route', custom.custom, name='custom'),
 	# url(r'^user/$', custom.user, name='user'),
 	url(r'^multi/$', multi_request_view, name='multi_request'),
+	url(r'^handle_exceptions/$', handle_exceptions_view, name='handle_exceptions'),
 	url(r'^', include(router.urls)),
 	url(r'^', binder.views.api_catchall, name='catchall'),
 ]

--- a/tests/testapp/views/handle_exceptions.py
+++ b/tests/testapp/views/handle_exceptions.py
@@ -1,12 +1,13 @@
 from django.http import HttpResponse
 
-from binder.decorators import handle_exceptions
+from binder.decorators import handle_exceptions, allowed_methods
 from binder.exceptions import BinderRequestError
 
 from ..models import Zoo
 
 
 @handle_exceptions
+@allowed_methods('GET')
 def handle_exceptions_view(request):
 	# We create a model so we can test transaction rollback on error
 	Zoo.objects.create(name='Test zoo')

--- a/tests/testapp/views/handle_exceptions.py
+++ b/tests/testapp/views/handle_exceptions.py
@@ -1,0 +1,19 @@
+from django.http import HttpResponse
+
+from binder.decorators import handle_exceptions
+from binder.exceptions import BinderRequestError
+
+from ..models import Zoo
+
+
+@handle_exceptions
+def handle_exceptions_view(request):
+	# We create a model so we can test transaction rollback on error
+	Zoo.objects.create(name='Test zoo')
+
+	try:
+		res = request.GET['res']
+	except KeyError:
+		raise BinderRequestError('no res provided')
+	else:
+		return HttpResponse(res)


### PR DESCRIPTION
Adds a decorator `binder.decorators.handle_exceptions` that handles `BinderException`s in view functions in the same way as the `BinderView` does (Abort transaction and turn exception into a response using the request.).

Adds a decorator `binder.decorators.allowed_methods` that given some http method names wraps a view function to throw a `BinderMethodNotAllowed` when the request method is not one of these methods (Advantage over the django decorators for this is that this conforms to the standard binder error format.).

Also moves the decorator `binder.view_logger.view_logger` to `binder.decorators.view_logger`. The old path is still importable for backwards compatibility but will give a warning.