### PR TITLE
Fix M2M Saving breaking when the base model save fails

### DIFF
--- a/binder/views.py
+++ b/binder/views.py
@@ -1496,7 +1496,9 @@ class ModelView(View):
 				return
 			getattr(obj, field).set(value)
 		elif any(f.name == field for f in self.model._meta.many_to_many):
-			getattr(obj, field).set(value)
+			# Only try saving an m2m field if the base model field save was succesfull (checked by looking if it has id)
+			if obj.id:
+				getattr(obj, field).set(value)
 		else:
 			setattr(obj, field, value)
 

--- a/tests/test_m2m_store_errors.py
+++ b/tests/test_m2m_store_errors.py
@@ -19,8 +19,8 @@ class M2MStoreErrorsTest(TestCase):
 		self.assertTrue(r)
 
 	# When a model can not be saved due to validation errors its corresponding m2m models should also not be saved
-	# and correctly return a 418 validation error instead of a 500 error after still trying to save the m2m model
-	def test_saving_m2m_models_return_correct_418(self):
+	# and correctly return a 400 validation error instead of a 500 error after still trying to save the m2m model
+	def test_saving_m2m_models_return_correct_400(self):
 		model_data = {"data": [
 			{
 				"id": -4,

--- a/tests/test_m2m_store_errors.py
+++ b/tests/test_m2m_store_errors.py
@@ -1,0 +1,37 @@
+from django.contrib.auth.models import User
+from django.test import TestCase, Client
+
+import json
+from binder.json import jsonloads
+
+from django.test import TestCase
+
+
+class M2MStoreErrorsTest(TestCase):
+
+	def setUp(self):
+		super().setUp()
+		u = User(username='testuser', is_active=True, is_superuser=True)
+		u.set_password('test')
+		u.save()
+		self.client = Client()
+		r = self.client.login(username='testuser', password='test')
+		self.assertTrue(r)
+
+	# When a model can not be saved due to validation errors its corresponding m2m models should also not be saved
+	# and correctly return a 418 validation error instead of a 500 error after still trying to save the m2m model
+	def test_saving_m2m_models_return_correct_418(self):
+		model_data = {"data": [
+			{
+				"id": -4,
+				'name': '',
+				'most_popular_animals': [],
+				"contacts": [],
+				'opening_time': 'invalid opening time`'
+			}
+		],
+			"with": {}
+		}
+		response = self.client.put('/zoo/', data=json.dumps(model_data), content_type='application/json')
+		self.assertEqual(response.status_code, 400)
+		print(response.body)

--- a/tests/test_m2m_store_errors.py
+++ b/tests/test_m2m_store_errors.py
@@ -34,4 +34,3 @@ class M2MStoreErrorsTest(TestCase):
 		}
 		response = self.client.put('/zoo/', data=json.dumps(model_data), content_type='application/json')
 		self.assertEqual(response.status_code, 400)
-		print(response.body)


### PR DESCRIPTION
Currently in binder when a multiput is performed with a base model and m2m models django breaks if the base model is invalid. Reason for this is that the saving of the base model fails, but the saving of the m2m model is still tried after this.

We do sill want to check the m2m models for validation errors aswell, so not performing any of these checks is not an option. For this reason checking if the base model has an id is the best method .