### PR TITLE
Force skipping csrf when using token auth

### DIFF
--- a/binder/plugins/views/multi_request.py
+++ b/binder/plugins/views/multi_request.py
@@ -62,6 +62,11 @@ def multi_request_view(request):
 					e.log()
 					res = e.response(request)
 				else:
+					# There's a "sneaky little hack" in Django test client
+					# to avoid csrf checks in tests. This needs to be passed
+					# down to make sure tests for multi request are also skipping
+					# csrf checks. See also: https://github.com/django/django/blob/ebb08d19424c314c75908bc6048ff57c2f872269/django/test/client.py#L142
+					req._dont_enforce_csrf_checks = request._dont_enforce_csrf_checks
 					res = handler.get_response(req)
 
 				# Serialize and add to responses

--- a/docs/plugins/tokenauth.md
+++ b/docs/plugins/tokenauth.md
@@ -1,0 +1,47 @@
+# Token Auth
+
+To enable authentication using tokens, you can use the Token Auth plugin. Tokens are attached to users, and any action is seen as done by that user.
+
+# Installation
+
+Add to `settings.py`:
+
+```
+INSTALLED_APPS = [
+	...
+	'binder.plugins.token_auth',
+	...
+]
+```
+
+Then run the migrations:
+
+```
+./manage.py migrate
+```
+
+# Generate tokens
+
+
+The following snippet shows how to generate tokens for users.
+
+```
+from django.contrib.auth.models import User
+from binder.plugins.token_auth.models import Token
+
+token = Token(user=u)
+token.save()
+
+# Contains token to authenticate, for example 'test-token'.
+token.token
+```
+
+The token can be used in the `Authorization` header prefixed with `Token `. Take this example using curl:
+
+```
+curl --location --request POST 'http://localhost:1339/api/dfds/instruction/' --header 'Authorization: Token test-token' --data '{"foo":"bar"}'
+```
+
+# CSRF
+
+When using token auth, csrf is completely bypassed.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -36,6 +36,7 @@ settings.configure(**{
 		# TODO: Try to reduce the set of absolutely required middlewares
 		'request_id.middleware.RequestIdMiddleware',
 		'django.contrib.sessions.middleware.SessionMiddleware',
+		'django.middleware.csrf.CsrfViewMiddleware',
 		'django.contrib.auth.middleware.AuthenticationMiddleware',
 		'binder.plugins.token_auth.middleware.TokenAuthMiddleware',
 	],


### PR DESCRIPTION
It seems that token auth usage does not completely skip csrf auth. This
commit does skip it, and adds a test that POSTing using token auth
completely skips csrf.