### PR TITLE
Use original filename

### DIFF
--- a/binder/models.py
+++ b/binder/models.py
@@ -759,7 +759,7 @@ class BinderFileField(FileField):
 		return serialize_tuple((
 			value.name,
 			value.content_hash,
-			value.content_type,
+			value.content_type or '',
 		))
 
 	def deconstruct(self):

--- a/binder/models.py
+++ b/binder/models.py
@@ -601,20 +601,13 @@ class BinderFieldFile(FieldFile):
 				# To make sure we have as much compatibility as possible, this is tested in
 				#
 				# test_binder_file_field.test_reusing_same_file_for_multiple_fields
-				self.open('rb')
-				while True:
-					chunk = self.read(4096)
-					if not chunk:
-						break
-					hasher.update(chunk)
+				with open(self.path, 'rb') as fh:
+					while True:
+						chunk = fh.read(4096)
+						if not chunk:
+							break
+						hasher.update(chunk)
 				self._content_hash = hasher.hexdigest()
-				# with open(self.path, 'rb') as fh:
-				# 	while True:
-				# 		chunk = fh.read(4096)
-				# 		if not chunk:
-				# 			break
-				# 		hasher.update(chunk)
-				# self._content_hash = hasher.hexdigest()
 			except FileNotFoundError:
 				# In some rare cases, there seems to be a record in the db but the
 				# file is missing from disk. I've seen it a few times now, but have

--- a/binder/models.py
+++ b/binder/models.py
@@ -601,13 +601,20 @@ class BinderFieldFile(FieldFile):
 				# To make sure we have as much compatibility as possible, this is tested in
 				#
 				# test_binder_file_field.test_reusing_same_file_for_multiple_fields
-				with open(self.path, 'rb') as fh:
-					while True:
-						chunk = fh.read(4096)
-						if not chunk:
-							break
-						hasher.update(chunk)
+				self.open('rb')
+				while True:
+					chunk = self.read(4096)
+					if not chunk:
+						break
+					hasher.update(chunk)
 				self._content_hash = hasher.hexdigest()
+				# with open(self.path, 'rb') as fh:
+				# 	while True:
+				# 		chunk = fh.read(4096)
+				# 		if not chunk:
+				# 			break
+				# 		hasher.update(chunk)
+				# self._content_hash = hasher.hexdigest()
 			except FileNotFoundError:
 				# In some rare cases, there seems to be a record in the db but the
 				# file is missing from disk. I've seen it a few times now, but have

--- a/binder/models.py
+++ b/binder/models.py
@@ -13,7 +13,6 @@ from django.contrib.postgres.fields import CITextField, ArrayField, JSONField
 from django.core import checks
 from django.core.files.base import File, ContentFile
 from django.core.files.images import ImageFile
-from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.db.models import signals
 from django.core.exceptions import ValidationError
 from django.db.models.query_utils import Q
@@ -616,7 +615,7 @@ class BinderFieldFile(FieldFile):
 					#
 					# test_binder_file_field.test_reusing_same_file_for_multiple_fields
 					with open(self.path, 'rb') as fh:
-						self._content_hash =  self.calculate_hash(fh)
+						self._content_hash = self.calculate_hash(fh)
 
 			except FileNotFoundError:
 				# In some rare cases, there seems to be a record in the db but the

--- a/binder/models.py
+++ b/binder/models.py
@@ -732,8 +732,9 @@ class BinderFileField(FileField):
 
 	def __init__(self, *args, **kwargs):
 		# Since we also need to store a content type and a hash in the field
-		# we up the default max_length from 100 to 200
-		kwargs.setdefault('max_length', 200)
+		# we up the default max_length from 100 to 200. Now we store also
+		# the original file name, so lets make it 400 chars.
+		kwargs.setdefault('max_length', 400)
 		return super().__init__(*args, **kwargs)
 
 	def get_prep_value(self, value):
@@ -757,10 +758,9 @@ class BinderFileField(FileField):
 
 	def deconstruct(self):
 		name, path, args, kwargs = super().deconstruct()
-		# Standard file field omits max length when it is 100 so we readd that
-		# as the default and then omit if it is 200, which is our default
-		if kwargs.setdefault('max_length', 100) == 200:
-			del kwargs['max_length']
+
+		# FileField doesn't return max_length if it is 100, because that is the Django default.
+		kwargs.setdefault('max_length', 100)
 		return name, path, args, kwargs
 
 

--- a/binder/views.py
+++ b/binder/views.py
@@ -485,9 +485,10 @@ class ModelView(View):
 
 						# {duplicate-binder-file-field-hash-code}
 						if isinstance(f, BinderFileField):
-							data[f.name] += '?h={}&content_type={}'.format(
+							data[f.name] += '?h={}&content_type={}&filename={}'.format(
 								file.content_hash,
 								file.content_type,
+								file.name,
 							)
 					else:
 						data[f.name] = None
@@ -2323,16 +2324,13 @@ class ModelView(View):
 						format = format_override
 						changes = True
 
+					filename = '{}.{}'.format(os.path.basename(file.name), format)
+
 					if changes:
 						file = io.BytesIO()
 						img.save(file, format)
-
-					filename = '{}.{}'.format(obj.id, format)
 				else:
-					if file.name.find('.') != -1:
-						filename = '{}.{}'.format(obj.id, file.name.split('.')[-1])
-					else:
-						filename = str(obj.id)
+					filename = file.name
 
 				# FIXME: duplicate code
 				if file_field:
@@ -2362,9 +2360,10 @@ class ModelView(View):
 
 				# {duplicate-binder-file-field-hash-code}
 				if isinstance(field, BinderFileField):
-					path += '?h={}&content_type={}'.format(
+					path += '?h={}&content_type={}&filename={}'.format(
 						file_field.content_hash,
 						file_field.content_type,
+						file_field.name,
 					)
 
 				return JsonResponse( {"data": {file_field_name: path}} )

--- a/binder/views.py
+++ b/binder/views.py
@@ -488,7 +488,7 @@ class ModelView(View):
 							data[f.name] += '?h={}&content_type={}&filename={}'.format(
 								file.content_hash,
 								file.content_type,
-								file.name,
+								os.path.basename(file.name),
 							)
 					else:
 						data[f.name] = None
@@ -2363,7 +2363,7 @@ class ModelView(View):
 					path += '?h={}&content_type={}&filename={}'.format(
 						file_field.content_hash,
 						file_field.content_type,
-						file_field.name,
+						os.path.basename(file_field.name),
 					)
 
 				return JsonResponse( {"data": {file_field_name: path}} )

--- a/binder/views.py
+++ b/binder/views.py
@@ -487,7 +487,7 @@ class ModelView(View):
 						if isinstance(f, BinderFileField):
 							data[f.name] += '?h={}&content_type={}&filename={}'.format(
 								file.content_hash,
-								file.content_type,
+								file.content_type or '',
 								os.path.basename(file.name),
 							)
 					else:
@@ -2362,7 +2362,7 @@ class ModelView(View):
 				if isinstance(field, BinderFileField):
 					path += '?h={}&content_type={}&filename={}'.format(
 						file_field.content_hash,
-						file_field.content_type,
+						file_field.content_type or '',
 						os.path.basename(file_field.name),
 					)
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -19,25 +19,48 @@ class Animal(BinderModel):
 
 When a model has a file attached to it, the url normally becomes something like this:
 
-`/api/some_model/123/some_file_name/`
+`/api/some_model/123/some_file/`
 
 In this case, the frontend has to hit the file endpoint to know if the file has changes. When using BinderFileField / BinderImageField, the url will contain extra info encoded in the url:
 
-`/api/some_model/123/some_file_name/?h=0759a35e9983833ce52fe433d2326addf400f344&content_type=image/jpeg`
+`/api/some_model/123/some_file/?h=0759a35e9983833ce52fe433d2326addf400f344&content_type=image/jpeg&filename=sample.pdf`
 
-- `h`: The sha1 of the file.
-- `content_type`: The content type of the file.
+| key | description |
+| - | - |
+| `h` | The sha1 of the file. You can use this to check if the file has changed. |
+| `content_type` | The content type of the file. |
+| `filename` |  The name of the file. This can be used for the `download` attribute of an anchor. |
 
 You can upgrade from default Django FileField / ImageField as follows:
 
-Old: `picture = models.FileField(blank=True, null=True)`
-New: `picture = BinderFileField(blank=True, null=True)`
+```
+# FileField
+picture = models.FileField(blank=True, null=True) # Old
+picture = BinderFileField(blank=True, null=True) # New
 
-Old: `picture = models.ImageField(blank=True, null=True)`
-New: `picture = BinderImageField(blank=True, null=True)`
+# ImageField
+picture = models.ImageField(blank=True, null=True) # Old
+picture = BinderImageField(blank=True, null=True) # New
+```
 
 Then, run `manage.py makemigrations` to add the required migrations.
 
+---
+> **_IMPORTANT:_** If you upgrade from an older BinderFileField to one that also includes filename, you unfortunately need to manually change your old migration file before you run makemigrations:
+
+```
+migrations.AlterField(
+    ...
+    # Old: without specifying `max_length=200`
+    # field=binder.models.BinderImageField(blank=True, upload_to='document/file/%Y/%m/%d/'),
+
+    # Manual change: add `max_length=200`
+    field=binder.models.BinderImageField(blank=True, upload_to='document/file/%Y/%m/%d/', max_length=200),
+)
+```
+When manually changed, Django will then correctly make new migration files.
+
+---
 
 ## Enums
 

--- a/tests/test_binder_file_field.py
+++ b/tests/test_binder_file_field.py
@@ -1,3 +1,4 @@
+from os.path import basename
 from io import BytesIO
 from PIL import Image
 
@@ -50,7 +51,7 @@ class BinderFileFieldTest(TestCase):
 
 		# Remove once Django 3 lands with: https://docs.djangoproject.com/en/3.1/howto/custom-file-storage/#django.core.files.storage.get_alternative_name
 		zoo.refresh_from_db()
-		filename = zoo.binder_picture.name
+		filename = basename(zoo.binder_picture.name) # Without folders foo/bar/
 
 		self.assertEqual(
 			content['data']['binder_picture'],
@@ -77,7 +78,7 @@ class BinderFileFieldTest(TestCase):
 
 		# Remove once Django 3 lands with: https://docs.djangoproject.com/en/3.1/howto/custom-file-storage/#django.core.files.storage.get_alternative_name
 		zoo.refresh_from_db()
-		filename = zoo.binder_picture.name
+		filename = basename(zoo.binder_picture.name) # Without folders foo/bar/
 
 		self.assertEqual(
 			data['data']['binder_picture'],

--- a/tests/test_binder_file_field.py
+++ b/tests/test_binder_file_field.py
@@ -95,6 +95,34 @@ class BinderFileFieldTest(TestCase):
 			'/zoo/{}/binder_picture/?h={}&content_type=&filename={}'.format(zoo.pk, HASH, filename),
 		)
 
+	def test_post_with_long_filename(self):
+		filename = 'this_is_an_extremely_long_filename_which_should_be_over_200_chars_but_under_400_and_im_running_out_of_things_to_say_and_i_guess_we_just_keep_going_and_im_now_in_poznan_working_onsite_perhaps_thats_interesting_and_just_ordered_pizza_for_lunch.jpg'
+		zoo = Zoo(name='Apenheul')
+		zoo.save()
+
+		response = self.client.post('/zoo/%s/binder_picture/' % zoo.id, data={
+			'file': ContentFile(CONTENT, name=filename),
+		})
+		self.assertEqual(response.status_code, 200)
+		content = jsonloads(response.content)
+
+		# Remove once Django 3 lands with: https://docs.djangoproject.com/en/3.1/howto/custom-file-storage/#django.core.files.storage.get_alternative_name
+		zoo.refresh_from_db()
+		filename = basename(zoo.binder_picture.name) # Without folders foo/bar/
+
+		self.assertEqual(
+			content['data']['binder_picture'],
+			'/zoo/{}/binder_picture/?h={}&content_type=image/jpeg&filename={}'.format(zoo.pk, HASH, filename),
+		)
+
+		response = self.client.get('/zoo/{}/'.format(zoo.pk))
+		self.assertEqual(response.status_code, 200)
+		data = jsonloads(response.content)
+		self.assertEqual(
+			data['data']['binder_picture'],
+			'/zoo/{}/binder_picture/?h={}&content_type=image/jpeg&filename={}'.format(zoo.pk, HASH, filename),
+		)
+
 	def test_get(self):
 		filename = 'pic.jpg'
 		zoo = Zoo(name='Apenheul')

--- a/tests/testapp/models/zoo.py
+++ b/tests/testapp/models/zoo.py
@@ -24,8 +24,8 @@ class Zoo(BinderModel):
 	most_popular_animals = models.ManyToManyField('Animal', blank=True, related_name='+')
 	opening_time = models.TimeField(default=datetime.time(9, 0, 0))
 
-	django_picture = models.ImageField(blank=True, null=True)
-	binder_picture = BinderImageField(blank=True, null=True)
+	django_picture = models.ImageField(upload_to='foo/bar/%Y/%m/%d/', blank=True, null=True)
+	binder_picture = BinderImageField(upload_to='foo/bar/%Y/%m/%d/', blank=True, null=True)
 
 	django_picture_not_null = models.ImageField(blank=True)
 	binder_picture_not_null = BinderImageField(blank=True)


### PR DESCRIPTION
Now binder renames the files to use the id instead of the name.