### PR TITLE
Parse negative answers to null value filters

### DIFF
--- a/binder/views.py
+++ b/binder/views.py
@@ -999,7 +999,7 @@ class ModelView(View):
 
 				# If we have a isnull qualifier, the value is not parsed really. That means that if we do not
 				# do anything isnull=False => isnull=True. Which makes no sense at all.
-				if qualifier == 'isnull' and value in ['0', 'False', 'false', '']:
+				if qualifier == 'isnull' and value in ['0', 'False', 'false']:
 					invert ^= True # Invert the invert
 
 

--- a/binder/views.py
+++ b/binder/views.py
@@ -996,6 +996,13 @@ class ModelView(View):
 				elif qualifier.startswith('not:'):
 					qualifier = qualifier[4:]
 					invert = True
+
+				# If we have a isnull qualifier, the value is not parsed really. That means that if we do not
+				# do anything isnull=False => isnull=True. Which makes no sense at all.
+				if qualifier == 'isnull' and value in ['0', 'False', 'false', '']:
+					invert ^= True # Invert the invert
+
+
 			except ValueError:
 				qualifier = None
 

--- a/tests/filters/test_datetime_filters.py
+++ b/tests/filters/test_datetime_filters.py
@@ -165,3 +165,17 @@ class DateTimeFiltersTest(TestCase):
 		# We only get bob back with no data
 		self.assertEqual(1, len(result['data']))
 		self.assertEqual('Bob', result['data'][0]['name'])
+
+	def test_datetime__isnull_false(self):
+		# Due to corona, I forgot when I last saw bob
+		Caretaker(name='Bob', last_seen=None).save()
+
+		for false_value in ['0', 'false', 'False']:
+
+			response = self.client.get('/caretaker/', data={'.last_seen:isnull': false_value})
+			result = jsonloads(response.content)
+
+			# We only get bob back with no data
+			self.assertEqual(2, len(result['data']))
+			self.assertNotEqual('Bob', result['data'][0]['name'])
+			self.assertNotEqual('Bob', result['data'][1]['name'])


### PR DESCRIPTION
Make sure that 

`.foo:isnull=False <=> .foo:not:isnull=True`

In the current behaviour:
`.foo:isnull=False <=> .foo:isnull=True`