### PR TITLE
When model validation has errors, leave reverse relations

### DIFF
--- a/binder/views.py
+++ b/binder/views.py
@@ -1396,10 +1396,7 @@ class ModelView(View):
 
 		try:
 			obj.save()
-			if obj.pk is None:
-				# Something went wrong while creating/updating the object, and no validation
-				# errors were raised, something must be wrong...
-				raise RuntimeError('Error while saving object')
+			assert(obj.pk is not None) # At this point, the object must have been created.
 		except ValidationError as ve:
 			validation_errors.append(self.binder_validation_error(obj, ve, pk=pk))
 

--- a/tests/test_m2m_store_errors.py
+++ b/tests/test_m2m_store_errors.py
@@ -49,6 +49,12 @@ class M2MStoreErrorsTest(TestCase):
 		response = self.client.put('/zoo/', data=json.dumps(model_data), content_type='application/json')
 		self.assertEqual(response.status_code, 400)
 
+	def assert_validation_error_as_response(self, response):
+		"""Assert that the backend sends us the validation error."""
+		self.assertEqual(jsonloads(response.content)['code'], 'ValidationError')
+		self.assertIn('Very special validation check that we need in `tests.M2MStoreErrorsTest`.', str(response.content))
+		self.assertEqual(response.status_code, 400)
+
 	def test_saving_m2m_with_model_validation_error(self):
 		"""Forward m2m field saving should not crash when there are model validation errors."""
 		model_data = {"data": [
@@ -63,7 +69,7 @@ class M2MStoreErrorsTest(TestCase):
 		}
 
 		response = self.client.put('/zoo/', data=json.dumps(model_data), content_type='application/json')
-		self.assertEqual(response.status_code, 400)
+		self.assert_validation_error_as_response(response)
 
 	def test_saving_reverse_m2m_with_model_validation_error(self):
 		"""Reverse m2m field saving should not crash when there are model validation errors."""
@@ -78,7 +84,7 @@ class M2MStoreErrorsTest(TestCase):
 		}
 
 		response = self.client.put('/contact_person/', data=json.dumps(model_data), content_type='application/json')
-		self.assertEqual(response.status_code, 400)
+		self.assert_validation_error_as_response(response)
 
 	def test_saving_reverse_fk_with_validation_error(self):
 		"""Reverse foreign key field saving should not crash when there are model validation errors."""
@@ -96,7 +102,7 @@ class M2MStoreErrorsTest(TestCase):
 		}
 
 		response = self.client.put('/zoo/', data=json.dumps(model_data), content_type='application/json')
-		self.assertEqual(response.status_code, 400)
+		self.assert_validation_error_as_response(response)
 
 	def test_saving_o2o_with_validation_error(self):
 		"""Reverse o2o field saving should not crash when there are model validation errors."""
@@ -114,4 +120,4 @@ class M2MStoreErrorsTest(TestCase):
 		}
 
 		response = self.client.put('/contact_person/', data=json.dumps(model_data), content_type='application/json')
-		self.assertEqual(response.status_code, 400)
+		self.assert_validation_error_as_response(response)

--- a/tests/test_m2m_store_errors.py
+++ b/tests/test_m2m_store_errors.py
@@ -6,8 +6,21 @@ from binder.json import jsonloads
 
 from django.test import TestCase
 
+from .testapp.models import Animal, ContactPerson, Zoo
+
 
 class M2MStoreErrorsTest(TestCase):
+	"""
+	(T30296) When model saving fails due to model validation errors (from `clean()` for example), related field
+	saving should not crash.
+	This involves:
+	- m2m fields
+	- reverse m2m fields
+	- reverse o2o fields
+	- reverse fk fields
+
+	This test depends on some validation rule added to `ContactPerson` and `Zoo`.
+	"""
 
 	def setUp(self):
 		super().setUp()
@@ -20,6 +33,7 @@ class M2MStoreErrorsTest(TestCase):
 
 	# When a model can not be saved due to validation errors its corresponding m2m models should also not be saved
 	# and correctly return a 400 validation error instead of a 500 error after still trying to save the m2m model
+	# validation error is caused by a field in this test
 	def test_saving_m2m_models_return_correct_400(self):
 		model_data = {"data": [
 			{
@@ -33,4 +47,71 @@ class M2MStoreErrorsTest(TestCase):
 			"with": {}
 		}
 		response = self.client.put('/zoo/', data=json.dumps(model_data), content_type='application/json')
+		self.assertEqual(response.status_code, 400)
+
+	def test_saving_m2m_with_model_validation_error(self):
+		"""Forward m2m field saving should not crash when there are model validation errors."""
+		model_data = {"data": [
+			{
+				'id': -4,
+				'name': 'very_special_forbidden_zoo_name', # trigger model validation error
+				'opening_time': '08:00',
+				'contacts': [], # m2m field on Zoo
+			}
+		],
+			"with": {}
+		}
+
+		response = self.client.put('/zoo/', data=json.dumps(model_data), content_type='application/json')
+		self.assertEqual(response.status_code, 400)
+
+	def test_saving_reverse_m2m_with_model_validation_error(self):
+		"""Reverse m2m field saving should not crash when there are model validation errors."""
+		model_data = {"data": [
+			{
+				'id': -4,
+				'name': 'very_special_forbidden_contact_person_name', # trigger model validation error
+				'zoos': [], # this is the related_name, actual m2m field is on Zoo
+			}
+		],
+			"with": {}
+		}
+
+		response = self.client.put('/contact_person/', data=json.dumps(model_data), content_type='application/json')
+		self.assertEqual(response.status_code, 400)
+
+	def test_saving_reverse_fk_with_validation_error(self):
+		"""Reverse foreign key field saving should not crash when there are model validation errors."""
+		animal = Animal(name='Paard')
+		animal.save()
+
+		model_data = {"data": [
+			{
+				'id': -4,
+				'name': 'very_special_forbidden_zoo_name', # trigger model validation error
+				'animals': [animal.pk], # animals have a fk to zoo
+			}
+		],
+			"with": {}
+		}
+
+		response = self.client.put('/zoo/', data=json.dumps(model_data), content_type='application/json')
+		self.assertEqual(response.status_code, 400)
+
+	def test_saving_o2o_with_validation_error(self):
+		"""Reverse o2o field saving should not crash when there are model validation errors."""
+		zoo = Zoo(name='Awesome zoo')
+		zoo.save()
+
+		model_data = {"data": [
+			{
+				'id': -4,
+				'name': 'very_special_forbidden_contact_person_name', # trigger model validation error
+				'managing_zoo': zoo.pk,
+			}
+		],
+			"with": {}
+		}
+
+		response = self.client.put('/contact_person/', data=json.dumps(model_data), content_type='application/json')
 		self.assertEqual(response.status_code, 400)

--- a/tests/testapp/models/contact_person.py
+++ b/tests/testapp/models/contact_person.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.core.exceptions import ValidationError
 from binder.models import BinderModel
 
 class ContactPerson(BinderModel):
@@ -8,3 +9,10 @@ class ContactPerson(BinderModel):
 
 	def __str__(self):
 		return 'contact_person %d: %s' % (self.pk, self.name)
+
+	def clean(self):
+		if self.name == 'very_special_forbidden_contact_person_name':
+			raise ValidationError(
+				code='invalid',
+				message='Very special validation check that we need in `tests.M2MStoreErrorsTest`.'
+			)

--- a/tests/testapp/models/zoo.py
+++ b/tests/testapp/models/zoo.py
@@ -20,7 +20,10 @@ class Zoo(BinderModel):
 	name = models.TextField()
 	founding_date = models.DateField(null=True, blank=True)
 	floor_plan = models.ImageField(upload_to='floor-plans', null=True, blank=True)
+	# It is important that this m2m relationship is defined on this model, one of the tests depends on this fact
 	contacts = models.ManyToManyField('ContactPerson', blank=True, related_name='zoos')
+	# We assume that a person can only be the director of one zoo, one of the tests depends on this fact
+	director = models.OneToOneField('ContactPerson', on_delete=models.SET_NULL, blank=True, null=True, related_name='managing_zoo')
 	most_popular_animals = models.ManyToManyField('Animal', blank=True, related_name='+')
 	opening_time = models.TimeField(default=datetime.time(9, 0, 0))
 
@@ -41,6 +44,12 @@ class Zoo(BinderModel):
 
 
 	def clean(self):
+		if self.name == 'very_special_forbidden_zoo_name':
+			raise ValidationError(
+				code='invalid',
+				message='Very special validation check that we need in `tests.M2MStoreErrorsTest`.'
+			)
+
 		errors = {}
 
 		if self.floor_plan and self.name == 'Nowhere':


### PR DESCRIPTION
Currently, when there are model validation errors, thrown by `clean()` for example, we still try to go on and save related fields of the four 'reverse relationship' types: reverse fk, reverse one to one, m2m and reverse m2m. I created four tests that try to reproduce these situations. Bob already added a check for the m2m case, but I think that this check is needed before the `_store_m2m_fields` method is even called, because my test fail in those cases.

See T30296 for more context.