### PR TITLE
Add support for multiple writable databases

### DIFF
--- a/binder/views.py
+++ b/binder/views.py
@@ -8,6 +8,8 @@ import datetime
 import mimetypes
 import functools
 from collections import defaultdict, namedtuple
+from contextlib import ExitStack
+
 from PIL import Image
 from inspect import getmro
 
@@ -366,7 +368,9 @@ class ModelView(View):
 		response = None
 		try:
 			#### START TRANSACTION
-			with transaction.atomic(), history.atomic(source='http', user=request.user, uuid=request.request_id):
+			with ExitStack() as stack, history.atomic(source='http', user=request.user, uuid=request.request_id):
+				for db in django.conf.settings.get('TRANSACTION_DATABASES', ['default']):
+					stack.enter_context(transaction.atomic(using=db))
 				is_unauthenticated_endpoint = kwargs.pop('unauthenticated', False)
 				user_is_authenticated = request.user.is_authenticated
 

--- a/binder/views.py
+++ b/binder/views.py
@@ -369,7 +369,15 @@ class ModelView(View):
 		try:
 			#### START TRANSACTION
 			with ExitStack() as stack, history.atomic(source='http', user=request.user, uuid=request.request_id):
-				for db in django.conf.settings.get('TRANSACTION_DATABASES', ['default']):
+				transaction_dbs = ['default']
+
+				# Check if the TRANSACTION_DATABASES is set in the settings.py, and if so, use that instead
+				try:
+					transaction_dbs = django.conf.settings.TRANSACTION_DATABASES
+				except AttributeError:
+					pass
+
+				for db in transaction_dbs:
 					stack.enter_context(transaction.atomic(using=db))
 				is_unauthenticated_endpoint = kwargs.pop('unauthenticated', False)
 				user_is_authenticated = request.user.is_authenticated


### PR DESCRIPTION
Add `TRANSACTION_DATABASES` setting, to allow for multiple databases to be in a transaction. Defaults to only the default database