### PR TITLE
Fix encoding issue filefield

### DIFF
--- a/binder/views.py
+++ b/binder/views.py
@@ -9,7 +9,7 @@ import mimetypes
 import functools
 from collections import defaultdict, namedtuple
 from contextlib import ExitStack
-from unicode import unicode
+from unidecode import unidecode
 
 from PIL import Image
 from inspect import getmro

--- a/binder/views.py
+++ b/binder/views.py
@@ -9,6 +9,7 @@ import mimetypes
 import functools
 from collections import defaultdict, namedtuple
 from contextlib import ExitStack
+from unicode import unicode
 
 from PIL import Image
 from inspect import getmro
@@ -2268,7 +2269,8 @@ class ModelView(View):
 				raise BinderNotFound(file_field_name)
 
 			if 'download' in request.GET:
-				filename = self.filefield_get_name(instance=obj, request=request, file_field=file_field)
+				# unidecode in order to prevent weird utf-8 symbols from messing with our urls, causing issues
+				filename = unidecode(self.filefield_get_name(instance=obj, request=request, file_field=file_field))
 				if 'prefix' in request.GET:
 					filename = request.GET['prefix'] + ' - ' + filename
 				resp['Content-Disposition'] = 'attachment; filename="{}"'.format(filename)

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
 		'Pillow >= 3.2.0',
 		'django-request-id >= 1.0.0',
 		'requests >= 2.13.0',
+		'unidecode >= 1.2.0'
 	],
 	tests_require=[
 		'django-hijack >= 2.1.10',


### PR DESCRIPTION
Currently BinderFileFields which contain some characters like the [accent grave](https://en.wikipedia.org/wiki/Grave_accent) will break download links when ran in combination with gunicorn to serve url links etc.

This is solved by using unidecode to always replace these characters with their ascii code equivalent, which gunicorn can process.