### PR TITLE
Add support for dictionaries, sets  and list for excel export

### DIFF
--- a/binder/plugins/views/csvexport.py
+++ b/binder/plugins/views/csvexport.py
@@ -116,6 +116,11 @@ class ExcelFileAdapter(ExportFileAdapter):
 
 	def add_row(self, values: List[str]):
 		for (column_id, value) in enumerate(values):
+
+			# The excel library doesn't implicitely cast this to string, so do it explicitely to prevent
+			# the export from crashing
+			if type(value) in [dict, list, set]:
+				value = str(value)
 			self.sheet.cell(column=column_id + 1, row=self._row_number + 1, value=value)
 		self._row_number += 1
 

--- a/binder/plugins/views/csvexport.py
+++ b/binder/plugins/views/csvexport.py
@@ -284,7 +284,12 @@ class CsvExportView:
 					else:
 						# Assume that we have a mapping now
 						fk_ids = data[head_key]
-						if type(fk_ids) != list:
+
+						if fk_ids is None:
+							# This case happens if we have a nullable foreign key that is null. Treat this as a many
+							# to one relation with no values. 
+							fk_ids = []
+						elif type(fk_ids) != list:
 							fk_ids = [fk_ids]
 
 						# if head_key not in key_mapping:

--- a/tests/testapp/models/__init__.py
+++ b/tests/testapp/models/__init__.py
@@ -9,7 +9,7 @@ from .costume import Costume
 from .gate import Gate
 from .nickname import Nickname, NullableNickname
 from .lion import Lion
-from .picture import Picture
+from .picture import Picture, PictureBook
 from .zoo import Zoo
 from .zoo_employee import ZooEmployee
 from .city import City, CityState, PermanentCity

--- a/tests/testapp/models/picture.py
+++ b/tests/testapp/models/picture.py
@@ -13,6 +13,18 @@ def delete_files(sender, instance=None, **kwargs):
 			except Exception:
 				pass
 
+
+class PictureBook(BinderModel):
+	"""
+	Sometimes customers like to commemorate their visit to the zoo. Of course there are always some shitty pictures that
+	we do not want in a picture album
+
+	"""
+
+	name = models.TextField()
+
+
+
 # At the website of the zoo there are some pictures of animals. This model links the picture to an animal.
 #
 # A picture has two files, the original uploaded file, and the modified file. This model is used for testing the
@@ -21,6 +33,7 @@ class Picture(BinderModel):
 	animal = models.ForeignKey('Animal', on_delete=models.CASCADE, related_name='picture')
 	file = models.ImageField(upload_to='floor-plans')
 	original_file = models.ImageField(upload_to='floor-plans')
+	picture_book = models.ForeignKey('PictureBook', on_delete=models.CASCADE, null=True, blank=True)
 
 	def __str__(self):
 		return 'picture %d: (Picture for animal %s)' % (self.pk or 0, self.animal.name)

--- a/tests/testapp/views/__init__.py
+++ b/tests/testapp/views/__init__.py
@@ -15,7 +15,7 @@ if os.environ.get('BINDER_TEST_MYSQL', '0') != '1':
 from .gate import GateView
 from .lion import LionView
 from .nickname import NicknameView
-from .picture import PictureView
+from .picture import PictureView, PictureBookView
 from .user import UserView
 from .zoo import ZooView
 from .zoo_employee import ZooEmployeeView

--- a/tests/testapp/views/picture.py
+++ b/tests/testapp/views/picture.py
@@ -3,16 +3,19 @@ from binder.router import list_route
 from binder.views import ModelView
 from binder.plugins.views import ImageView, CsvExportView
 
-from ..models import Picture
+from ..models import Picture, PictureBook
 
+class PictureBookView(ModelView):
+	model = PictureBook
 
 class PictureView(ModelView, ImageView, CsvExportView):
 	model = Picture
 	file_fields = ['file', 'original_file']
-	csv_settings = CsvExportView.CsvExportSettings(['animal'], [
+	csv_settings = CsvExportView.CsvExportSettings(['animal', 'picture_book'], [
 		('id', 'picture identifier'),
 		('animal.id', 'animal identifier'),
 		('id', 'squared picture identifier', lambda id, row, mapping: id**2),
+		('picture_book.name', 'Picturebook name')
 	])
 
 	@list_route(name='download_csv', methods=['GET'])

--- a/tests/testapp/views/picture.py
+++ b/tests/testapp/views/picture.py
@@ -5,8 +5,10 @@ from binder.plugins.views import ImageView, CsvExportView
 
 from ..models import Picture, PictureBook
 
+
 class PictureBookView(ModelView):
 	model = PictureBook
+
 
 class PictureView(ModelView, ImageView, CsvExportView):
 	model = Picture
@@ -15,7 +17,10 @@ class PictureView(ModelView, ImageView, CsvExportView):
 		('id', 'picture identifier'),
 		('animal.id', 'animal identifier'),
 		('id', 'squared picture identifier', lambda id, row, mapping: id**2),
-		('picture_book.name', 'Picturebook name')
+		('picture_book.name', 'Picturebook name'),
+		('id', 'dictionary_example', lambda id, row, mapping: {'id': id}),
+		('id', 'list_example', lambda id, row, mapping: [id]),
+		('id', 'set_example', lambda id, row, mapping: {id})
 	])
 
 	@list_route(name='download_csv', methods=['GET'])


### PR DESCRIPTION
Currently the excel export crashes if the CSVExport module returns a dictionary, list or set. This does work for the CSV export though. This adds support for these types.

This PR build upon https://github.com/CodeYellowBV/django-binder/pull/188