### PR TITLE
File upload copy fix

### DIFF
--- a/binder/views.py
+++ b/binder/views.py
@@ -1606,7 +1606,9 @@ class ModelView(View):
 		except model.DoesNotExist:
 			return None
 
-		return getattr(obj, field)
+		value = getattr(obj, field)
+		with value.open('rb') as f:
+			return ContentFile(f.read(), value.name)
 
 
 	def _clean_image_file(self, field, value):


### PR DESCRIPTION
Currently there is a quite nasty bug in master.

- Suppose there is a model called `Model` with a file field called `file`.
- If we have 2 instances of this model with id 1 and id 2.
- If the field `file` is fileld for the model with id 1.
- If we do `PUT /api/model/2/ {"file": "/api/model/1/file/"}` this will now save a reference to the same file in the database for model 2 as for model 1.
- If we now update the file on model 2 the old file will be deleted.
- Model 1 now has a reference to a file that does not exist.