### PR TITLE
Fix unclosed files

### DIFF
--- a/tests/test_binder_file_field.py
+++ b/tests/test_binder_file_field.py
@@ -212,6 +212,21 @@ class BinderFileFieldTest(TestCase):
 			'/zoo/{}/binder_picture/?h={}&content_type=image/jpeg&filename={}'.format(zoo.pk, '', 'non-exisiting-pic.jpg'),
 		)
 
+	def test_post_image_doesnt_leave_unclosed_file(self):
+		zoo = Zoo(name='Apenheul')
+		zoo.save()
+
+		# Basically this construction of assertRaise wrapped around assertWarns
+		# is to make sure no warning is triggered. This works, since assertWarns
+		# raises an AssertionError. Basically a `self.assertNotWarns`.
+		with self.assertRaises(AssertionError) as cm:
+			with self.assertWarns(ResourceWarning):
+				response = self.client.post('/zoo/%s/binder_picture_custom_extensions/' % zoo.id, data={
+					'file': ContentFile(CONTENT, name='foobar.png'),
+				})
+
+		self.assertEqual(str(cm.exception), 'ResourceWarning not triggered')
+
 
 class BinderFileFieldBlankNotNullableTest(TestCase):
 	def setUp(self):


### PR DESCRIPTION
Some files were not closed properly, which causes at some point too many
open files on the server.