### PR TITLE
Add test for unclosed files bug

### DIFF
--- a/binder/models.py
+++ b/binder/models.py
@@ -12,7 +12,7 @@ from django.db import models
 from django.db.models.fields.files import FieldFile, FileField
 from django.contrib.postgres.fields import CITextField, ArrayField, JSONField, DateTimeRangeField as DTRangeField
 from django.core import checks
-from django.core.files.base import File, ContentFile
+from django.core.files.base import File
 from django.core.files.images import ImageFile
 from django.db.models import signals
 from django.core.exceptions import ValidationError

--- a/binder/models.py
+++ b/binder/models.py
@@ -664,8 +664,9 @@ class BinderFieldFile(FieldFile):
 					# this is tested in:
 					#
 					# test_binder_file_field.test_reusing_same_file_for_multiple_fields
-					with open(self.path, 'rb') as fh:
-						self._content_hash = self.calculate_hash(fh)
+					fh = self.storage.open(self.name, 'rb')
+					self._content_hash = self.calculate_hash(fh)
+					fh.close()
 
 			except FileNotFoundError:
 				# In some rare cases, there seems to be a record in the db but the

--- a/binder/models.py
+++ b/binder/models.py
@@ -646,16 +646,22 @@ class BinderFieldFile(FieldFile):
 			self._content_hash = None
 		elif self._content_hash is None:
 			try:
+				# Directly access `self._file` instead of accessor `self.file`
+				# (see the crucial `_`). If you use `self.file`, it will open
+				# the file, see also:
+				#
+				# https://github.com/django/django/blob/b55699968fc9ee985384c64e37f6cc74a0a23683/django/db/models/fields/files.py#L45
 				if isinstance(self._file, ContentFile):
 					fh = self.open('rb')
 					self._content_hash = self.calculate_hash(fh)
 				else:
-					# Don't use self.open, since it then closes self.file. Apparently
-					# Django requires this here:
+					# Don't use self.open, since it then closes self.file.
+					# Apparently Django requires this here:
 					#
 					# https://github.com/django/django/blob/master/django/core/files/uploadedfile.py#L91
 					#
-					# To make sure we have as much compatibility as possible, this is tested in
+					# To make sure we have as much compatibility as possible,
+					# this is tested in:
 					#
 					# test_binder_file_field.test_reusing_same_file_for_multiple_fields
 					with open(self.path, 'rb') as fh:

--- a/binder/models.py
+++ b/binder/models.py
@@ -618,17 +618,19 @@ def parse_tuple(content):
 
 	return tuple(values)
 
-def calculate_file_hash(path):
-	with open(path, 'rb') as fh:
-		hasher = hashlib.sha1()
 
+def calculate_file_hash(path):
+	hasher = hashlib.sha1()
+
+	with open(path, 'rb') as fh:
 		while True:
 			chunk = fh.read(4096)
 			if not chunk:
 				break
 			hasher.update(chunk)
 
-		return hasher.hexdigest()
+	return hasher.hexdigest()
+
 
 class BinderFieldFile(FieldFile):
 	"""

--- a/binder/models.py
+++ b/binder/models.py
@@ -618,6 +618,17 @@ def parse_tuple(content):
 
 	return tuple(values)
 
+def calculate_file_hash(path):
+	with open(path, 'rb') as fh:
+		hasher = hashlib.sha1()
+
+		while True:
+			chunk = fh.read(4096)
+			if not chunk:
+				break
+			hasher.update(chunk)
+
+		return hasher.hexdigest()
 
 class BinderFieldFile(FieldFile):
 	"""
@@ -629,37 +640,21 @@ class BinderFieldFile(FieldFile):
 		self._content_hash = content_hash
 		self._content_type = content_type
 
-	def calculate_hash(self, fh):
-		hasher = hashlib.sha1()
-
-		while True:
-			chunk = fh.read(4096)
-			if not chunk:
-				break
-			hasher.update(chunk)
-
-		return hasher.hexdigest()
-
 	@property
 	def content_hash(self):
 		if not self.name:
 			self._content_hash = None
 		elif self._content_hash is None:
 			try:
-				if isinstance(self.file, ContentFile):
-					fh = self.open('rb')
-					self._content_hash = self.calculate_hash(fh)
-				else:
-					# Don't use self.open, since it then closes self.file. Apparently
-					# Django requires this here:
-					#
-					# https://github.com/django/django/blob/master/django/core/files/uploadedfile.py#L91
-					#
-					# To make sure we have as much compatibility as possible, this is tested in
-					#
-					# test_binder_file_field.test_reusing_same_file_for_multiple_fields
-					with open(self.path, 'rb') as fh:
-						self._content_hash = self.calculate_hash(fh)
+				# Don't use self.open, since it then closes self.file. Apparently
+				# Django requires this here:
+				#
+				# https://github.com/django/django/blob/master/django/core/files/uploadedfile.py#L91
+				#
+				# To make sure we have as much compatibility as possible, this is tested in
+				#
+				# test_binder_file_field.test_reusing_same_file_for_multiple_fields
+				self._content_hash = calculate_file_hash(self.path)
 
 			except FileNotFoundError:
 				# In some rare cases, there seems to be a record in the db but the

--- a/binder/models.py
+++ b/binder/models.py
@@ -646,7 +646,7 @@ class BinderFieldFile(FieldFile):
 			self._content_hash = None
 		elif self._content_hash is None:
 			try:
-				if isinstance(self.file, ContentFile):
+				if isinstance(self._file, ContentFile):
 					fh = self.open('rb')
 					self._content_hash = self.calculate_hash(fh)
 				else:

--- a/tests/test_binder_file_field.py
+++ b/tests/test_binder_file_field.py
@@ -215,6 +215,21 @@ class BinderFileFieldTest(TestCase):
 			'/zoo/{}/binder_picture/?h={}&content_type=image/jpeg&filename={}'.format(zoo.pk, '', 'non-exisiting-pic.jpg'),
 		)
 
+	def test_post_image_doesnt_leave_unclosed_file(self):
+		zoo = Zoo(name='Apenheul')
+		zoo.save()
+
+		# Basically this construction of assertRaise wrapped around assertWarns
+		# is to make sure no warning is triggered. This works, since assertWarns
+		# raises an AssertionError. Basically a `self.assertNotWarns`.
+		with self.assertRaises(AssertionError) as cm:
+			with self.assertWarns(ResourceWarning):
+				response = self.client.post('/zoo/%s/binder_picture_custom_extensions/' % zoo.id, data={
+					'file': ContentFile(PNG_CONTENT, name='foobar.png'),
+				})
+
+		self.assertEqual(str(cm.exception), 'ResourceWarning not triggered')
+
 
 class BinderFileFieldBlankNotNullableTest(TestCase):
 	def setUp(self):

--- a/tests/test_binder_file_field.py
+++ b/tests/test_binder_file_field.py
@@ -227,7 +227,6 @@ class BinderFileFieldTest(TestCase):
 				response = self.client.post('/zoo/%s/binder_picture_custom_extensions/' % zoo.id, data={
 					'file': ContentFile(PNG_CONTENT, name='foobar.png'),
 				})
-			print(cm2.warning)
 
 		self.assertEqual(str(cm.exception), 'ResourceWarning not triggered')
 

--- a/tests/test_binder_file_field.py
+++ b/tests/test_binder_file_field.py
@@ -223,10 +223,11 @@ class BinderFileFieldTest(TestCase):
 		# is to make sure no warning is triggered. This works, since assertWarns
 		# raises an AssertionError. Basically a `self.assertNotWarns`.
 		with self.assertRaises(AssertionError) as cm:
-			with self.assertWarns(ResourceWarning):
+			with self.assertWarns(ResourceWarning) as cm2:
 				response = self.client.post('/zoo/%s/binder_picture_custom_extensions/' % zoo.id, data={
 					'file': ContentFile(PNG_CONTENT, name='foobar.png'),
 				})
+			print(cm2.warning)
 
 		self.assertEqual(str(cm.exception), 'ResourceWarning not triggered')
 


### PR DESCRIPTION
Some files were not closed properly, which causes at some point too many
open files on the server. This was fixed somewhere down the line, this
adds a regression test.