### PR TITLE
Import get_user_model instead User model from django.contrib.auth

### DIFF
--- a/binder/history.py
+++ b/binder/history.py
@@ -4,7 +4,7 @@ import warnings
 
 from django.db import models
 from django.http import HttpResponse
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.conf import settings
 from django.dispatch import Signal
 
@@ -214,7 +214,7 @@ def view_changesets(request, changesets):
 			userids.add(cs.user_id)
 
 	users = []
-	for u in User.objects.filter(id__in=userids):
+	for u in get_user_model().objects.filter(id__in=userids):
 		users.append({'id': u.id, 'username': u.username, 'email': u.email, 'first_name': u.first_name, 'last_name': u.last_name})
 
 	return JsonResponse({'data': data, 'with': {'user': users}})


### PR DESCRIPTION
Fix an issue 'auth.User' has been swapped for 'assets.User'
use get_user_model() instead of getting models from django.contrib.auth
Check https://docs.djangoproject.com/en/4.0/topics/auth/customizing/