### PR TITLE
Add HTML field plugin

### DIFF
--- a/binder/plugins/models/__init__.py
+++ b/binder/plugins/models/__init__.py
@@ -1,0 +1,1 @@
+from .html_field import HtmlField

--- a/binder/plugins/models/html_field.py
+++ b/binder/plugins/models/html_field.py
@@ -1,0 +1,11 @@
+from django.db.models import TextField
+
+
+class HtmlField(TextField):
+	"""
+	Determine a safe way to save "secure" user provided HTML input, and prevent
+	"""
+
+
+	def validate(self, value, _):
+		pass

--- a/binder/plugins/models/html_field.py
+++ b/binder/plugins/models/html_field.py
@@ -1,4 +1,74 @@
 from django.db.models import TextField
+from html.parser import HTMLParser
+from django.core import exceptions
+
+
+def link_validator(tag, attribute_name, attribute_value):
+	if not attribute_value.startswith('http://') and not attribute_value.startswith('https://'):
+		raise exceptions.ValidationError(
+			'Link is not valid',
+			code='invalid_tag',
+			params={
+				'tag': tag,
+			},
+		)
+
+class HtmlValidator(HTMLParser):
+	allowed_tags = [
+		# General setup
+		'p', 'br',
+		# Headers
+		'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'h7',
+
+		# text decoration
+		'b', 'strong', 'i', 'em', 'u',
+		# Lists
+		'ol', 'ul', 'li',
+
+		# Special
+		'a',
+	]
+
+	allowed_attributes = {
+		'a': ['href', 'rel', 'target']
+	}
+
+	special_validators = {
+		('a', 'href'): link_validator
+	}
+
+	error_messages = {
+		'invalid_tag': 'Tag %(tag)s is not allowed',
+		'invalid_attribute': 'Attribute %(attribute)s not allowed for tag %(tag)s'
+	}
+
+
+
+	def handle_starttag(self, tag: str, attrs: list) -> None:
+		if tag not in self.allowed_tags:
+			raise exceptions.ValidationError(
+				self.error_messages['invalid_tag'],
+				code='invalid_tag',
+				params={
+					'tag': tag
+				},
+			)
+
+		allowed_attributes_for_tag = self.allowed_attributes.get(tag,[])
+
+		for (attribute_name, attribute_content) in attrs:
+			if attribute_name not in allowed_attributes_for_tag:
+				raise exceptions.ValidationError(
+					self.error_messages['invalid_attribute'],
+					code='invalid_tag',
+					params={
+						'tag': tag,
+						'attribute': attribute_name
+					},
+				)
+			if (tag, attribute_name) in self.special_validators:
+				self.special_validators[(tag, attribute_name)](tag, attribute_name, attribute_content)
+
 
 
 class HtmlField(TextField):
@@ -6,6 +76,7 @@ class HtmlField(TextField):
 	Determine a safe way to save "secure" user provided HTML input, and prevent
 	"""
 
-
 	def validate(self, value, _):
-		pass
+		# Validate all html tags
+		validator = HtmlValidator()
+		validator.feed(value)

--- a/tests/test_html_field.py
+++ b/tests/test_html_field.py
@@ -1,0 +1,26 @@
+from django.contrib.auth.models import User
+from django.test import TestCase, Client
+
+from project.testapp.models import Zoo, WebPage
+
+
+class AnnotationTestCase(TestCase):
+
+	def setUp(self):
+		super().setUp()
+		u = User(username='testuser', is_active=True, is_superuser=True)
+		u.set_password('test')
+		u.save()
+		self.client = Client()
+		r = self.client.login(username='testuser', password='test')
+		self.assertTrue(r)
+
+		self.zoo = Zoo(name='Apenheul')
+		self.zoo.save()
+
+		self.webpage = WebPage(zoo=self.zoo, content='')
+
+
+	def test_save_normal_text_ok(self):
+		self.webpage = WebPage(zoo=self.zoo, content='Artis')
+

--- a/tests/test_html_field.py
+++ b/tests/test_html_field.py
@@ -1,10 +1,11 @@
 from django.contrib.auth.models import User
 from django.test import TestCase, Client
 
-from project.testapp.models import Zoo, WebPage
+import json
+from .testapp.models import Zoo, WebPage
 
 
-class AnnotationTestCase(TestCase):
+class HtmlFieldTestCase(TestCase):
 
 	def setUp(self):
 		super().setUp()
@@ -18,9 +19,46 @@ class AnnotationTestCase(TestCase):
 		self.zoo = Zoo(name='Apenheul')
 		self.zoo.save()
 
-		self.webpage = WebPage(zoo=self.zoo, content='')
-
+		self.webpage = WebPage.objects.create(zoo=self.zoo, content='')
 
 	def test_save_normal_text_ok(self):
-		self.webpage = WebPage(zoo=self.zoo, content='Artis')
+		response = self.client.put(f'/web_page/{self.webpage.id}/', data=json.dumps({'content': 'Artis'}))
+		self.assertEqual(response.status_code, 200)
 
+	def test_simple_html_is_ok(self):
+		response = self.client.put(f'/web_page/{self.webpage.id}/',
+								   data=json.dumps({'content': '<h1>Artis</h1><b><p>Artis is a zoo in amsterdam</a>'}))
+		self.assertEqual(response.status_code, 200)
+
+	def test_wrong_attribute_not_ok(self):
+		response = self.client.put(f'/web_page/{self.webpage.id}/',
+								   data=json.dumps({'content': '<b onclick="">test</b>'}))
+		self.assertEqual(response.status_code, 400)
+
+	def test_simple_link_is_ok(self):
+		response = self.client.put(f'/web_page/{self.webpage.id}/', data=json.dumps(
+			{'content': '<a href="https://www.artis.nl/en/">Visit artis website</a>'}))
+		self.assertEqual(response.status_code, 200)
+
+	def test_javascript_link_is_not_ok(self):
+		response = self.client.put(f'/web_page/{self.webpage.id}/',
+								   data=json.dumps({
+													   'content': '<a href="javascrt:alert(document.cookie)">Visit artis website</a>'}))
+		self.assertEqual(response.status_code, 400)
+
+
+
+	def test_script_is_not_ok(self):
+		response = self.client.put(f'/web_page/{self.webpage.id}/',
+								   data=json.dumps({'content': '<script>alert(\'hoi\');</script>'}))
+		self.assertEqual(response.status_code, 400)
+
+	def test_can_handle_reallife_data(self):
+		"""
+		This is the worst case that we could produce on the WYIWYG edittor
+		"""
+		content = '<p>normal text</p><p><br></p><h1>HEADing 1</h1><p><br></p><h2>HEADING 2</h2><h3><br></h3><h3>HEADING 3</h3><p><br></p><p><strong>bold</strong></p><p><br></p><p><em>italic</em></p><p><br></p><p><u>underlined</u></p><p><br></p><p><a href=\"http://codeyellow.nl\" rel=\"noopener noreferrer\" target=\"_blank\">Link</a></p><p><br></p><ol><li>ol1</li><li>ol2</li></ol><ul><li>ul1</li><li>ul2</li></ul><p><br></p><p>subscripttgege</p><p>g</p>"'
+		response = self.client.put(f'/web_page/{self.webpage.id}/',
+								   data=json.dumps({'content': content}))
+
+		self.assertEqual(response.status_code, 200)

--- a/tests/testapp/models/__init__.py
+++ b/tests/testapp/models/__init__.py
@@ -14,6 +14,8 @@ from .zoo import Zoo
 from .zoo_employee import ZooEmployee
 from .city import City, CityState, PermanentCity
 from .country import Country
+from .web_page import WebPage
+
 # This is Postgres-specific
 if os.environ.get('BINDER_TEST_MYSQL', '0') != '1':
 	from .timetable import TimeTable

--- a/tests/testapp/models/web_page.py
+++ b/tests/testapp/models/web_page.py
@@ -1,0 +1,13 @@
+
+from binder.models import BinderModel
+from django.db import models
+
+from binder.plugins.models import HtmlField
+
+
+class WebPage(BinderModel):
+	"""
+	Every zoo has a webpage containing some details about the zoo
+	"""
+	zoo = models.OneToOneField('Zoo', related_name='web_page', on_delete=models.CASCADE)
+	content = HtmlField()

--- a/tests/testapp/views/__init__.py
+++ b/tests/testapp/views/__init__.py
@@ -19,3 +19,4 @@ from .picture import PictureView
 from .user import UserView
 from .zoo import ZooView
 from .zoo_employee import ZooEmployeeView
+from .web_page import WebPageView

--- a/tests/testapp/views/web_page.py
+++ b/tests/testapp/views/web_page.py
@@ -1,0 +1,7 @@
+from binder.views import ModelView
+
+from ..models import WebPage
+
+# From the api docs
+class WebPageView(ModelView):
+	model = WebPage


### PR DESCRIPTION
Adds a plugin to binder adding a HTML field. This field has validation of the html content. It can be used for a CMS, where the user can save HTML, while preventing XSS attacks from occuring. 
