### PR TITLE
Use persistent RabbitMQ connection

### DIFF
--- a/binder/websocket.py
+++ b/binder/websocket.py
@@ -1,3 +1,4 @@
+from threading import Semaphore, Thread
 from django.conf import settings
 
 from .json import jsondumps
@@ -30,22 +31,54 @@ class RoomController(object):
         return rooms
 
 
+use_channel_function = None
+sent_channel_task_semaphore = Semaphore(0)
+finished_channel_task_semaphore = Semaphore(0)
+
+def use_channel(use_function):
+    global use_channel_function
+    global sent_channel_task_semaphore
+    global finished_channel_task_semaphore
+
+    if use_channel_function is None:
+        use_channel_function = [None]
+
+        def connection_thread_function():
+            import pika
+            connection_credentials = pika.PlainCredentials(
+                settings.HIGH_TEMPLAR['rabbitmq']['username'],
+                settings.HIGH_TEMPLAR['rabbitmq']['password'],
+            )
+            connection_parameters = pika.ConnectionParameters(
+                settings.HIGH_TEMPLAR['rabbitmq']['host'],
+                credentials=connection_credentials,
+            )
+            connection = pika.BlockingConnection(parameters=connection_parameters)
+            channel = connection.channel()
+
+            while True:
+                has_task = sent_channel_task_semaphore.acquire(timeout=0.01)
+                if has_task:
+                    use_channel_function[0](channel)
+                    finished_channel_task_semaphore.release()
+                connection.process_data_events(0)
+
+        connection_thread = Thread(target=connection_thread_function)
+        connection_thread.setDaemon(True)
+        connection_thread.start()
+
+    use_channel_function[0] = use_function
+    sent_channel_task_semaphore.release()
+    finished_channel_task_semaphore.acquire()
+
 def trigger(data, rooms):
     if 'rabbitmq' in getattr(settings, 'HIGH_TEMPLAR', {}):
-        import pika
-        from pika import BlockingConnection
-
-        connection_credentials = pika.PlainCredentials(settings.HIGH_TEMPLAR['rabbitmq']['username'],
-                                                       settings.HIGH_TEMPLAR['rabbitmq']['password'])
-        connection_parameters = pika.ConnectionParameters(settings.HIGH_TEMPLAR['rabbitmq']['host'],
-                                                          credentials=connection_credentials)
-        connection = BlockingConnection(parameters=connection_parameters)
-        channel = connection.channel()
-
-        channel.basic_publish('hightemplar', routing_key='*', body=jsondumps({
-            'data': data,
-            'rooms': rooms,
-        }))
+        def use_function(channel):
+            channel.basic_publish('hightemplar', routing_key='*', body=jsondumps({
+                'data': data,
+                'rooms': rooms,
+            }))
+        use_channel(use_function)
     if getattr(settings, 'HIGH_TEMPLAR_URL', None):
         url = getattr(settings, 'HIGH_TEMPLAR_URL')
         try:


### PR DESCRIPTION
Currently, we create a new RabbitMQ connection each time we publish data. Since setting up and tearing down a connection can be quite some work, it is wasteful to do this for every single message.

This merge request ensures that only 1 RabbitMQ connection will be opened and that it will be reused each time we publish data. The connection will be managed on a background thread. This makes it possible to keep handling the connection heartbeat while the rest of the backend keeps running.

When publishing data, the data is first sent from the main thread to the background thread, and then published via the connection on the background thread. The main thread will wait until the background thread finishes publishing because some of our applications rely on this. This waiting is accomplished by using semaphores.