### PR TITLE
Fix bug with nullable default orderings in multi put

### DIFF
--- a/binder/models.py
+++ b/binder/models.py
@@ -941,7 +941,7 @@ class BinderImageField(BinderFileField):
 		if not file and not force:
 			return
 
-		dimension_fields_filled = not(
+		dimension_fields_filled = not (
 			(self.width_field and not getattr(instance, self.width_field)) or
 			(self.height_field and not getattr(instance, self.height_field))
 		)

--- a/binder/views.py
+++ b/binder/views.py
@@ -2330,7 +2330,7 @@ class ModelView(View):
 			# corresponding view here?  That would make it
 			# more consistent with non-multi-PUT and POST,
 			# also requiring view permissions.
-			qs = model.objects.filter(pk__in=oids).select_for_update()
+			qs = model.objects.filter(pk__in=oids).order_by().select_for_update()
 			for obj in qs:
 				locked_objects[(model, obj.pk)] = obj
 

--- a/binder/views.py
+++ b/binder/views.py
@@ -718,7 +718,7 @@ class ModelView(View):
 			for obj_id, data in datas_by_id.items():
 				# TODO: Don't require OneToOneFields in the m2m_fields list
 				if isinstance(local_field, models.OneToOneRel):
-					assert(len(idmap[obj_id]) <= 1)
+					assert len(idmap[obj_id]) <= 1
 					data[field_name] = idmap[obj_id][0] if len(idmap[obj_id]) == 1 else None
 				else:
 					data[field_name] = idmap[obj_id]
@@ -1634,7 +1634,7 @@ class ModelView(View):
 
 		try:
 			obj.save()
-			assert(obj.pk is not None) # At this point, the object must have been created.
+			assert obj.pk is not None # At this point, the object must have been created.
 		except ValidationError as ve:
 			validation_errors.append(self.binder_validation_error(obj, ve, pk=pk))
 

--- a/tests/test_model_view_basics.py
+++ b/tests/test_model_view_basics.py
@@ -5,7 +5,8 @@ from binder.json import jsonloads
 from django.contrib.auth.models import User
 
 from .compare import assert_json, EXTRA
-from .testapp.models import Animal, Costume, Zoo, ZooEmployee, Caretaker, Gate
+from .testapp.models import Animal, Costume, Zoo, ZooEmployee, Caretaker, Gate, Donor
+
 
 class ModelViewBasicsTest(TestCase):
 	def setUp(self):
@@ -821,3 +822,40 @@ class ModelViewBasicsTest(TestCase):
 			'meta': {'total_records': 1},
 			EXTRA(): None,  # Debug, meta, with, etc
 		})
+
+class TestModelViewBasicsWithNullableForeignKeyDefaultOrdering(TestCase):
+	def setUp(self):
+		super().setUp()
+		u = User(username='testuser', is_active=True, is_superuser=True)
+		u.set_password('test')
+		u.save()
+		self.client = Client()
+		r = self.client.login(username='testuser', password='test')
+		self.assertTrue(r)
+
+
+	def test_put_model_with_nullable_foreign_key_in_default_ordering(self):
+		donor = Donor.objects.create(name='Frits')
+
+		model_data = {
+			'name': 'Karel'
+		}
+
+		response = self.client.put(
+			'/donor/{}/?with=zoo'.format(donor.id),
+			data=json.dumps(model_data),
+			content_type='application/json'
+		)
+		self.assertEqual(response.status_code, 200)
+
+	def test_delete_model_with_nullable_foreign_key_in_default_ordering(self):
+		donor = Donor.objects.create(name='Frits')
+
+
+		response = self.client.delete(
+			'/donor/{}/?with=zoo'.format(donor.id),
+			data={},
+			content_type='application/json'
+		)
+
+		self.assertEqual(response.status_code, 204)

--- a/tests/test_multi_put.py
+++ b/tests/test_multi_put.py
@@ -654,3 +654,16 @@ class MultiPutDeletionsTest(TestCase):
 		response = self.client.put('/animal/', data=json.dumps(model_data), content_type='application/json')
 		self.assertEqual(response.status_code, 418)
 
+
+	def test_deletions_with_nullable_ordering(self):
+		donor = Donor(name='Frits')
+		donor.save()
+
+		model_data = {
+			'deletions': [donor.id],
+		}
+		response = self.client.put('/donor/', data=json.dumps(model_data), content_type='application/json')
+		self.assertEqual(response.status_code, 200)
+
+		with self.assertRaises(Donor.DoesNotExist):
+			donor.refresh_from_db()

--- a/tests/test_multi_put.py
+++ b/tests/test_multi_put.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 
 from binder.json import jsonloads
 
-from .testapp.models import Animal, Zoo, ZooEmployee, ContactPerson, Nickname, NullableNickname
+from .testapp.models import Animal, Zoo, ZooEmployee, ContactPerson, Nickname, NullableNickname,Donor
 from .compare import assert_json, MAYBE, ANY
 
 
@@ -553,6 +553,20 @@ class MultiPutTest(TestCase):
 		self.assertEqual(stimpy.nickname.id, nickname_id)
 
 
+	def test_multi_put_with_ordering_to_nullable_foreign_key(self):
+		donor = Donor(name='Frits')
+		donor.save()
+
+		model_data = {"data": [{
+				'id': donor.pk,
+				'name': 'Scooby Doo',
+			}]
+		}
+		response = self.client.put('/donor/', data=json.dumps(model_data), content_type='application/json')
+		self.assertEqual(response.status_code, 200)
+
+
+
 class MultiPutDeletionsTest(TestCase):
 
 	def setUp(self):
@@ -639,3 +653,4 @@ class MultiPutDeletionsTest(TestCase):
 		}
 		response = self.client.put('/animal/', data=json.dumps(model_data), content_type='application/json')
 		self.assertEqual(response.status_code, 418)
+

--- a/tests/testapp/models/__init__.py
+++ b/tests/testapp/models/__init__.py
@@ -3,6 +3,7 @@ import os
 
 # We have it all, from A to Z!
 from .animal import Animal
+from .donor import Donor
 from .caretaker import Caretaker
 from .contact_person import ContactPerson
 from .costume import Costume

--- a/tests/testapp/models/donor.py
+++ b/tests/testapp/models/donor.py
@@ -1,0 +1,20 @@
+from django.db import models
+from binder.models import BinderModel
+
+"""
+Unfortunately people in the zoo cannot pay everything by just the people visiting, so they depend on donors. There are some
+very wealthy donors in this detabase. They are a bit scared to give their money away. So they sponsor at most one zoo.
+
+Some donors however do not feel like giving money to any zoo at all.
+
+What is important about donors is that in general we want a list ordered by which zoo they are donating for.
+
+Note that this creates a nullable join in normal select queries, which triggers some very interesting edge cases
+"""
+class Donor(BinderModel):
+	zoo = models.ForeignKey('Zoo', null=True, blank=True, on_delete=models.SET_NULL)
+	name = models.TextField()
+
+	class Meta(BinderModel.Meta):
+		ordering = ('zoo',)
+

--- a/tests/testapp/views/__init__.py
+++ b/tests/testapp/views/__init__.py
@@ -20,3 +20,4 @@ from .user import UserView
 from .zoo import ZooView
 from .zoo_employee import ZooEmployeeView
 from .web_page import WebPageView
+from .donor import DonorView

--- a/tests/testapp/views/donor.py
+++ b/tests/testapp/views/donor.py
@@ -1,0 +1,9 @@
+
+from binder.views import ModelView
+
+from ..models import Animal, Donor
+
+
+# From the api docs
+class DonorView(ModelView):
+	model = Donor


### PR DESCRIPTION
Currently, when doing a multiput on a model with as default ordering containing a foreign key, a postgres is shown.

The error states "For update cannot be applied to the nullable side of an outerjoin"

This pull request fixes this