### PR TITLE
[BUGFIX] csv export null fk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 ## HEAD
 
+### BUGFIX csv export with null foreign keys
+CSV export will now work with null foreign keys
+
 ### Chained qualifiers
 Chained qualifiers have been added [T35707](https://phabricator.codeyellow.nl/T35707). For more information on how they work and how to use it see [documentation](/docs/api.md)
 

--- a/binder/plugins/views/csvexport.py
+++ b/binder/plugins/views/csvexport.py
@@ -289,6 +289,11 @@ class CsvExportView:
 					else:
 						# Assume that we have a mapping now
 						fk_ids = data[head_key]
+
+						# If foreign key is null don't try to fetch the data and stop
+						if not fk_ids:
+							return
+
 						if not isinstance(fk_ids, list):
 							fk_ids = [fk_ids]
 

--- a/tests/plugins/test_csvexport.py
+++ b/tests/plugins/test_csvexport.py
@@ -30,6 +30,7 @@ class CsvExportTest(TestCase):
 		animal = Animal(name='test')
 		animal.save()
 
+		self.animal = animal
 		self.pictures = []
 
 		for i in range(3):
@@ -124,6 +125,19 @@ class CsvExportTest(TestCase):
 		self.assertEqual(data[1], [str(caretaker_1.id), 'Foo', 'boo!'])
 		self.assertEqual(data[2], [str(caretaker_2.id), 'Bar', 'boo!'])
 		self.assertEqual(data[3], [str(caretaker_3.id), 'Baz', 'boo!'])
+
+	def test_null_foreign_keys_will_not_fail(self):
+		response = self.client.get('/animal/download/')
+		self.assertEqual(200, response.status_code)
+		response_data = csv.reader(io.StringIO(response.content.decode("utf-8")))
+
+		data = list(response_data)
+
+		# First line needs to be the header
+		self.assertEqual(data[0], ['ID', 'Zoo ID', 'Caretaker ID'])
+
+		# All other data needs to be ordered using the default ordering (by id, asc)
+		self.assertEqual(data[1], [str(self.animal.id), '', ''])
 
 	def test_context_aware_download_xlsx(self):
 		response = self.client.get('/picture/download/?response_type=xlsx')

--- a/tests/testapp/views/animal.py
+++ b/tests/testapp/views/animal.py
@@ -3,9 +3,12 @@ from django.db.models import Count, Value
 from binder.views import ModelView, Stat
 
 from ..models import Animal
+from binder.plugins.views import CsvExportView
 
 # From the api docs
-class AnimalView(ModelView):
+
+
+class AnimalView(ModelView, CsvExportView):
 	model = Animal
 	m2m_fields = ['costume']
 	searches = ['name__icontains']
@@ -21,3 +24,11 @@ class AnimalView(ModelView):
 			group_by='zoo.name',
 		),
 	}
+	csv_settings = CsvExportView.CsvExportSettings(
+		withs=['zoo', 'caretaker'],
+		column_map=[
+			('id', 'ID'),
+			('zoo.id', 'Zoo ID'),
+			('caretaker.id', 'Caretaker ID'),
+		],
+	)


### PR DESCRIPTION
When trying to do a csv export of an object with null fk like:

"order.trailer.id"

It was crashing when trailer was a null object as it tried to fetch id data from null object. This has been fixed. Test is added and changelog updated.