### PR TITLE
Fix multiput with proxy submodels

### DIFF
--- a/binder/views.py
+++ b/binder/views.py
@@ -2325,8 +2325,17 @@ class ModelView(View):
 		# Collect overrides
 		for (cls, mid), data in objects.items():
 			for subcls in getsubclasses(cls):
+				# Get remote field of the subclass
+				remote_field = subcls._meta.pk.remote_field
+
+				# In some scenarios with proxy models
+				# The remote field may not exist
+				# Because proxy models are just pure python wrappers(without its own db table) for other models
+				if remote_field is None:
+					continue
+
 				# Get key of field pointing to subclass
-				subkey = subcls._meta.pk.remote_field.name
+				subkey = remote_field.name
 				# Get id of subclass
 				subid = data.pop(subkey, None)
 				if subid is None:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@ version: '3'
 
 services:
   db:
-    image: postgres:11.5
+    image: postgres:12
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
   binder:
     build: .
     command: tail -f /dev/null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,6 @@
-version: '3'
-
 services:
   db:
-    image: postgres:12
-    environment:
-      - POSTGRES_HOST_AUTH_METHOD=trust
+    image: postgres:11.5
   binder:
     build: .
     command: tail -f /dev/null

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
 		'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
 	],
 	install_requires=[
-		'Django >= 3.0, < 5.0',
+		'Django >= 3.0, < 4.0',
 		'Pillow >= 3.2.0',
 		'django-request-id >= 1.0.0',
 		'requests >= 2.13.0',

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -122,3 +122,24 @@ class InheritanceTest(TestCase):
 		zoo = Zoo.objects.get(pk=zoo_id)
 		zoo_animal_ids = [animal.id for animal in zoo.animals.all()]
 		self.assertEqual(zoo_animal_ids, [animal_id])
+
+	def test_multiput_class_that_has_proxy_subclass(self):
+		response = self.client.put(
+			'/animal/',
+			content_type='application/json',
+			data=json.dumps({
+				'data': [{
+					'id': -1,
+					'name': 'Kowalsky',
+				}],
+				'with': {
+					'zoo': [{
+						'id': -3,
+						'name': 'Artis',
+						'animals': [-1],
+					}],
+				},
+			}),
+		)
+
+		self.assertEqual(response.status_code, 200)

--- a/tests/testapp/models/__init__.py
+++ b/tests/testapp/models/__init__.py
@@ -16,6 +16,7 @@ from .zoo_employee import ZooEmployee
 from .city import City, CityState, PermanentCity
 from .country import Country
 from .web_page import WebPage
+from .pet import Pet
 
 # This is Postgres-specific
 if os.environ.get('BINDER_TEST_MYSQL', '0') != '1':

--- a/tests/testapp/models/pet.py
+++ b/tests/testapp/models/pet.py
@@ -1,0 +1,7 @@
+from binder.models import BinderModel
+
+from .animal import Animal
+
+class Pet(Animal):
+    class Meta(BinderModel.Meta):
+        proxy = True

--- a/tests/testapp/views/__init__.py
+++ b/tests/testapp/views/__init__.py
@@ -21,3 +21,4 @@ from .zoo import ZooView
 from .zoo_employee import ZooEmployeeView
 from .web_page import WebPageView
 from .donor import DonorView
+from .pet import PetView

--- a/tests/testapp/views/pet.py
+++ b/tests/testapp/views/pet.py
@@ -1,0 +1,6 @@
+from binder.views import ModelView
+
+from ..models import Pet
+
+class PetView(ModelView):
+	model = Pet


### PR DESCRIPTION
This PR fixes a bug where in some scenarios, when using multiput on a models that have proxy submodel(a submodel without a db table) it would fail on trying to override superclass for that model instance(`_multi_put_override_superclass` method in the `views.py` file).

Example stacktrace of the error:
```
Traceback (most recent call last):
  File "/binder/tests/test_inheritance.py", line 93, in test_create_lion_with_animal_and_zoo
    response = self.client.put(
               ^^^^^^^^^^^^^^^^
  File "/binder/.eggs/Django-4.2.11-py3.12.egg/django/test/client.py", line 1026, in put
    response = super().put(
               ^^^^^^^^^^^^
  File "/binder/.eggs/Django-4.2.11-py3.12.egg/django/test/client.py", line 537, in put
    return self.generic(
           ^^^^^^^^^^^^^
  File "/binder/.eggs/Django-4.2.11-py3.12.egg/django/test/client.py", line 609, in generic
    return self.request(**r)
           ^^^^^^^^^^^^^^^^^
  File "/binder/.eggs/Django-4.2.11-py3.12.egg/django/test/client.py", line 891, in request
    self.check_exception(response)
  File "/binder/.eggs/Django-4.2.11-py3.12.egg/django/test/client.py", line 738, in check_exception
    raise exc_value
  File "/binder/.eggs/Django-4.2.11-py3.12.egg/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/binder/.eggs/Django-4.2.11-py3.12.egg/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/binder/.eggs/Django-4.2.11-py3.12.egg/django/views/generic/base.py", line 104, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/binder/binder/views.py", line 553, in dispatch
    response = super().dispatch(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/binder/.eggs/Django-4.2.11-py3.12.egg/django/views/generic/base.py", line 143, in dispatch
    return handler(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/binder/binder/views.py", line 2686, in put
    return self.multi_put(request)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/binder/binder/views.py", line 2609, in multi_put
    objects, overrides = self._multi_put_override_superclass(objects)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/binder/binder/views.py", line 2329, in _multi_put_override_superclass
    subkey = subcls._meta.pk.remote_field.name
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'name'
```

Given the purpose of that method I think it is not needed to override the superclass with proxy subclass- it is essentialy the same model from the db perspective. Thats why when this happens I added `continue` statement in the subclass loop, so it tries to search for a valid subclass for overriding.

Infact the newly added test is not really needed. Adding `Pet` proxy model, that inherits from `Animal` model is enough for existing inheritance tests to break. 

Additionaly after adding support for Django 4, the docker setup required bumping the version of Postgres container to 12 in order to work.