### PR TITLE
Make local testing use django 3.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,6 @@
-version: '3'
-
 services:
   db:
-    image: postgres:12
-    environment:
-      - POSTGRES_HOST_AUTH_METHOD=trust
+    image: postgres:11.5
   binder:
     build: .
     command: tail -f /dev/null

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
 		'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
 	],
 	install_requires=[
-		'Django >= 3.0, < 5.0',
+		'Django >= 3.0, < 4.0',
 		'Pillow >= 3.2.0',
 		'django-request-id >= 1.0.0',
 		'requests >= 2.13.0',


### PR DESCRIPTION
Local testing uses a different package install process then the CI. To prevent us running postgres 12 default while local testing bu use 11 instead we must also use django 3.

To enable this we in the setup.py which is used for local testing require a django 3 version instead of a django 3 or 4 version. Since django 4 is only postgres 12+ compatible.