### PR TITLE
Support serving files directly

### DIFF
--- a/binder/models.py
+++ b/binder/models.py
@@ -825,12 +825,13 @@ class BinderFileField(FileField):
 	attr_class = BinderFieldFile
 	descriptor_class = BinderFileDescriptor
 
-	def __init__(self, allowed_extensions=None, *args, **kwargs):
+	def __init__(self, allowed_extensions=None, serve_directly=False, *args, **kwargs):
 		# Since we also need to store a content type and a hash in the field
 		# we up the default max_length from 100 to 200. Now we store also
 		# the original file name, so lets make it 400 chars.
 		kwargs.setdefault('max_length', 400)
 		self.allowed_extensions = allowed_extensions
+		self.serve_directly = serve_directly
 		return super().__init__(*args, **kwargs)
 
 	def get_prep_value(self, value):
@@ -860,6 +861,7 @@ class BinderFileField(FileField):
 
 		if self.allowed_extensions:
 			kwargs['allowed_extensions'] = self.allowed_extensions
+		kwargs['serve_directly'] = self.serve_directly
 		return name, path, args, kwargs
 
 
@@ -903,11 +905,11 @@ class BinderImageField(BinderFileField):
 	descriptor_class = BinderImageFileDescriptor
 	description = _("Image")
 
-	def __init__(self, verbose_name=None, name=None, width_field=None, height_field=None, allowed_extensions=None, **kwargs):
+	def __init__(self, verbose_name=None, name=None, width_field=None, height_field=None, allowed_extensions=None, serve_directly=False, **kwargs):
 		self.width_field, self.height_field = width_field, height_field
 		if allowed_extensions is None:
 			allowed_extensions = ['png', 'gif', 'jpg', 'jpeg']
-		super().__init__(allowed_extensions, verbose_name, name, **kwargs)
+		super().__init__(allowed_extensions, serve_directly, verbose_name, name, **kwargs)
 
 	def check(self, **kwargs):
 		return [

--- a/docs/models.md
+++ b/docs/models.md
@@ -62,6 +62,12 @@ When manually changed, Django will then correctly make new migration files.
 
 ---
 
+#### Extra options
+
+* `allowed_extensions` (default: `None`): limits the file extensions that can be uploaded
+* `serve_directly` (default: `False`): delegates file serving to the web server (e.g. nginx)
+  * Requires configuration of `INTERNAL_MEDIA_HEADER` and `INTERNAL_MEDIA_LOCATION` in `settings.py`
+
 ## Enums
 
 Binder makes it easy to use enums.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -108,7 +108,9 @@ settings.configure(**{
 	},
 	'GROUP_CONTAINS': {
 		'admin': []
-	}
+	},
+	'INTERNAL_MEDIA_HEADER': 'X-Accel-Redirect',
+	'INTERNAL_MEDIA_LOCATION': '/internal/media/',
 })
 
 setup()
@@ -131,4 +133,3 @@ from django.contrib.auth.models import Group, Permission, ContentType
 content_type = ContentType.objects.get_or_create(app_label='testapp', model='country')[0]
 Permission.objects.get_or_create(content_type=content_type, codename='view_country')
 call_command('define_groups')
-

--- a/tests/testapp/models/zoo.py
+++ b/tests/testapp/models/zoo.py
@@ -43,6 +43,8 @@ class Zoo(BinderModel):
 
 	binder_picture_custom_extensions = BinderImageField(allowed_extensions=['png'], blank=True, null=True)
 
+	binder_picture_direct = BinderImageField(serve_directly=True, blank=True, null=True)
+
 	def __str__(self):
 		return 'zoo %d: %s' % (self.pk, self.name)
 

--- a/tests/testapp/views/zoo.py
+++ b/tests/testapp/views/zoo.py
@@ -11,12 +11,13 @@ class ZooView(PermissionView):
     m2m_fields = ['contacts', 'zoo_employees', 'most_popular_animals']
     model = Zoo
     file_fields = ['floor_plan', 'django_picture', 'binder_picture', 'django_picture_not_null',
-                   'binder_picture_not_null', 'binder_picture_custom_extensions']
+                   'binder_picture_not_null', 'binder_picture_custom_extensions', 'binder_picture_direct']
     shown_properties = ['animal_count']
     image_resize_threshold = {
         'floor_plan': 500,
         'binder_picture': 500,
         'binder_picture_custom_extensions': 500,
+        'binder_picture_direct': 500,
     }
     image_format_override = {
         'floor_plan': 'jpeg',


### PR DESCRIPTION
This PR adds the Boolean option `serve_directly` to `BinderFileField` and `BinderImageField`, with the default value `False`.

When set to `True`, a special header is added to HTTP responses that delegates the serving of the affected files to the web server (e.g. Nginx).