### PR TITLE
Django 5 update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.12"]
-        django-version: ["3.2.25", "4.2.11"]
+        django-version: ["3.2.25", "4.2.17", "5.1.4"]
         database-engine: ["postgres", "mysql"]
+        exclude:
+          - python-version: 3.8
+            django-version: 5.1.4
 
     services:
       postgres:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ jobs:
         python-version: ["3.8", "3.12"]
         django-version: ["3.2.25", "4.2.17", "5.1.4"]
         database-engine: ["postgres", "mysql"]
+        include:
+          - python-version: 3.7
+            django-version: 3.2.25
+            database-engine: postgres
         exclude:
           - python-version: 3.8
             django-version: 5.1.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,20 +4,28 @@ on: push
 
 jobs:
   check:
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
-        python-version: ["3.8", "3.12"]
+        # Testing Python 3.7 (deb 10), Python 3.9 (deb 11), Python 3.11 (deb 12)
+        python-version: ["3.9", "3.11"]
         django-version: ["3.2.25", "4.2.17", "5.1.4"]
         database-engine: ["postgres", "mysql"]
+        os: [ubuntu-latest]
         include:
+          # 3.7 cannot run on latest ubuntu
           - python-version: 3.7
             django-version: 3.2.25
             database-engine: postgres
+            os: ubuntu-22.04
+          - python-version: 3.7
+            django-version: 3.2.25
+            database-engine: mysql
+            os: ubuntu-22.04
         exclude:
-          - python-version: 3.8
+          - python-version: 3.9
             django-version: 5.1.4
+
+    runs-on: ${{ matrix.os }}
 
     services:
       postgres:
@@ -46,10 +54,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/binder/models.py
+++ b/binder/models.py
@@ -19,7 +19,9 @@ from django.core.files.images import ImageFile
 from django.db.models import signals
 from django.core.exceptions import ValidationError
 from django.db.models.query_utils import Q
-from django.utils import timezone
+from datetime import timezone
+from django.utils.timezone import get_fixed_timezone
+
 from django.utils.translation import gettext_lazy as _
 from django.utils.dateparse import parse_date, parse_datetime
 
@@ -343,7 +345,7 @@ class TimeFieldFilter(FieldFilter):
 			offset = int(tzinfo[1:3]) * 60 + int(tzinfo[3:5])
 			if tzinfo.startswith('-'):
 				offset = -offset
-			tzinfo = timezone.get_fixed_timezone(offset)
+			tzinfo = get_fixed_timezone(offset)
 		# Create time object
 		return time(
 			hour=hour,

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -1,4 +1,4 @@
-psycopg2<3.0
+psycopg2<3.2.3
 mysqlclient
 Pillow
 django-request-id

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
 	name='django-binder',
-	version='1.6.0',
+	version='1.7.0',
 	package_dir={'binder': 'binder'},
 	packages=find_packages(),
 	include_package_data=True,
@@ -27,6 +27,7 @@ setup(
 		'Framework :: Django',
 		'Framework :: Django :: 3.0',
 		'Framework :: Django :: 4.0',
+		'Framework :: Django :: 5.0',
 		'Intended Audience :: Developers',
 		'License :: OSI Approved :: MIT License',
 		'Operating System :: OS Independent',
@@ -36,7 +37,7 @@ setup(
 		'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
 	],
 	install_requires=[
-		'Django >= 3.0, < 5.0',
+		'Django >= 3.0, < 6.0',
 		'Pillow >= 3.2.0',
 		'django-request-id >= 1.0.0',
 		'requests >= 2.13.0',


### PR DESCRIPTION
- Update github ci testing matrix
Note that python 3.8 and django 5 are not compatible so add an exception
not to run that combination

- Update timezone import
Starting from django 5 the utc timezone should be imported from the
default python datetime library instead of the django specific library

- Fix get_fixed_timezone
The get_fixed_timezone method however is still needed from the django
library so import that seperatly