### PR TITLE
Prevent Excel export from generating two sheets

### DIFF
--- a/binder/plugins/views/csvexport.py
+++ b/binder/plugins/views/csvexport.py
@@ -91,7 +91,7 @@ class CsvFileAdapter(ExportFileAdapter):
 
 class ExcelFileAdapter(ExportFileAdapter):
 	"""
-	Adapter fore returning excel files
+	Adapter for returning excel files
 	"""
 	def __init__(self, request: HttpRequest):
 		super().__init__(request)
@@ -103,7 +103,7 @@ class ExcelFileAdapter(ExportFileAdapter):
 		# self.writer = self.pandas.ExcelWriter(self.response)
 
 		self.work_book = self.openpyxl.Workbook()
-		self.sheet = self.work_book.create_sheet()
+		self.sheet = self.work_book.active
 
 		# The row number we are currently writing to
 		self._row_number = 0

--- a/tests/plugins/test_csvexport.py
+++ b/tests/plugins/test_csvexport.py
@@ -70,7 +70,7 @@ class CsvExportTest(TestCase):
 			tmp.write(response.content)
 
 			wb = openpyxl.load_workbook(tmp.name)
-			sheet = wb._sheets[1]
+			sheet = wb._sheets[0]
 
 			_values = list(sheet.values)
 
@@ -133,7 +133,7 @@ class CsvExportTest(TestCase):
 			tmp.write(response.content)
 
 			wb = openpyxl.load_workbook(tmp.name)
-			sheet = wb._sheets[1]
+			sheet = wb._sheets[0]
 
 			_values = list(sheet.values)
 


### PR DESCRIPTION
Previously, the Excel export created a new sheet after creating the workbook, but the Workbook constructor already creates a default sheet. This caused customers to open the export and see the first, empty sheet, thinking the export was broken rather than clicking on the second sheet.