### PR TITLE
Include reverse OneToOne in with_related_name_mapping

### DIFF
--- a/binder/views.py
+++ b/binder/views.py
@@ -1054,7 +1054,9 @@ class ModelView(View):
 				related_model = field.remote_field.model
 				related_field = field.remote_field.related_name # For completeness
 
-			if field.remote_field.hidden: # Skip missing related fields
+			if field.remote_field.hidden and not isinstance(field, django.db.models.fields.reverse_related.OneToOneRel):
+				# Skip missing related fields, but not reverse OneToOne
+				# (reverse OneToOne always has a valid FK field on the child model)
 				related_field = None
 
 		except FieldDoesNotExist:

--- a/tests/test_model_view_basics.py
+++ b/tests/test_model_view_basics.py
@@ -560,6 +560,27 @@ class ModelViewBasicsTest(TestCase):
 		self.assertEqual(scrooge.pk, costume_by_id[frock.pk]['id'])
 		self.assertEqual(donald.pk, costume_by_id[sailor.pk]['id'])
 
+	def test_get_collection_with_reverse_one_to_one_mapping(self):
+		"""Reverse OneToOne should populate with_related_name_mapping.
+
+		When querying /animal/?with=costume, the response should include
+		with_related_name_mapping['costume'] == 'animal', so the frontend
+		can correctly resolve the FK field for reverse OneToOne relations.
+		"""
+		scrooge = Animal(name='Scrooge McDuck')
+		scrooge.save()
+
+		frock = Costume(description="Gentleman's frock coat", animal=scrooge)
+		frock.save()
+
+		response = self.client.get('/animal/', data={'order_by': 'name', 'with': 'costume'})
+		self.assertEqual(response.status_code, 200)
+
+		result = jsonloads(response.content)
+		# The key assertion: reverse OneToOne should have a proper with_related_name_mapping
+		self.assertIn('costume', result['with_related_name_mapping'])
+		self.assertEqual('animal', result['with_related_name_mapping']['costume'])
+
 	def test_get_model_with_relation_without_id(self):
 		gaia = Zoo(name='GaiaZOO')
 		gaia.save()


### PR DESCRIPTION
## Problem

For reverse OneToOne relations, field.remote_field.hidden is True, which caused related_field to be set to None in _follow_related(). This meant the entry was silently skipped from with_related_name_mapping in the API response.

This prevented the frontend (mobx-spine) from correctly resolving the FK field for reverse OneToOne relations, requiring a fragile heuristic workaround on the client side.

## Fix

Exclude OneToOneRel from the hidden check in _follow_related(), as reverse OneToOne always has a valid FK field on the child model.

## Testing

- All 430 existing tests pass
- Added new test test_get_collection_with_reverse_one_to_one_mapping that explicitly asserts with_related_name_mapping is populated for reverse OneToOne relations

## Impact

django-binder will now correctly populate with_related_name_mapping for all reverse OneToOne relations used in combination with mobx-spine.